### PR TITLE
include the protocol version in the generated code

### DIFF
--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -58,6 +58,8 @@ Map<String, Function> _typeFactories = {
 };
 
 class VmService {
+  static const String generatedServiceVersion = '2.0';
+
   StreamSubscription _streamSub;
   Function _writeMessage;
   int _id = 0;

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -58,7 +58,7 @@ Map<String, Function> _typeFactories = {
 };
 
 class VmService {
-  static const String generatedServiceVersion = '2.0';
+  static const String generatedServiceVersion = '2.0.0';
 
   StreamSubscription _streamSub;
   Function _writeMessage;

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -12,4 +12,5 @@ dev_dependencies:
   logging: ^0.11.0
   markdown: ^0.7.0
   path: ^1.0.0
+  pub_semver: ^1.0.0
   test: ^0.12.0

--- a/dart/tool/common/generate_common.dart
+++ b/dart/tool/common/generate_common.dart
@@ -56,7 +56,7 @@ class ApiParseUtil {
     var start = text.indexOf(new RegExp(r'\d+\.\d+'));
     if (start == -1) throw 'failed to find version';
     var index = text.indexOf('.', start);
-    var end = text.indexOf(new RegExp(r'!\d'), index + 1);
+    var end = text.indexOf(new RegExp(r'\D'), index + 1);
     if (end == -1) end = text.length;
     version.add(int.parse(text.substring(start, index)));
     version.add(int.parse(text.substring(index + 1, end)));

--- a/dart/tool/common/generate_common.dart
+++ b/dart/tool/common/generate_common.dart
@@ -5,6 +5,7 @@
 library generate_vm_service_lib_common;
 
 import 'package:markdown/markdown.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 import 'src_gen_common.dart';
 
@@ -19,7 +20,14 @@ class ApiParseUtil {
     Text text = node.children[0];
     Match match = regex.firstMatch(text.text);
     if (match == null) throw 'Unable to locate service protocol version';
-    return match.group(0);
+
+    String ver = match.group(0);
+
+    // Ensure that the version parses; this will throw a FormatException on
+    // parse errors.
+    new Version.parse(ver);
+
+    return ver;
   }
 
   /// Extract the current VM Service version number.

--- a/dart/tool/common/generate_common.dart
+++ b/dart/tool/common/generate_common.dart
@@ -8,11 +8,22 @@ import 'package:markdown/markdown.dart';
 
 import 'src_gen_common.dart';
 
-/// [ApiParseUtil] contains top level parsing utilities
+/// [ApiParseUtil] contains top level parsing utilities.
 class ApiParseUtil {
-  /// Extract the current VM Service version number
-  List<int> parseServiceVersion(List<Node> nodes) {
+  /// Extract the current VM Service version number as a String.
+  static String parseVersionString(List<Node> nodes) {
+    final RegExp regex = new RegExp(r'[\d.]+');
 
+    // Extract version from header: `# Dart VM Service Protocol 2.0`.
+    Element node = nodes.firstWhere((n) => isH1(n));
+    Text text = node.children[0];
+    Match match = regex.firstMatch(text.text);
+    if (match == null) throw 'Unable to locate service protocol version';
+    return match.group(0);
+  }
+
+  /// Extract the current VM Service version number.
+  List<int> parseServiceVersion(List<Node> nodes) {
     // Extract version from header
     // e.g. # Dart VM Service Protocol 2.0
     Element node = nodes.firstWhere((n) => isH1(n));

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -171,20 +171,13 @@ abstract class Member {
 }
 
 class Api extends Member with ApiParseUtil {
-  int serviceMajor;
-  int serviceMinor;
   String serviceVersion;
   List<Method> methods = [];
   List<Enum> enums = [];
   List<Type> types = [];
 
   void parse(List<Node> nodes) {
-    var version = parseServiceVersion(nodes);
-    serviceMajor = version[0];
-    serviceMinor = version[1];
-    serviceVersion = '$serviceMajor.$serviceMinor';
-    // TODO encode service version into generated dart
-    // and then compare it against what's returned by the running VM.
+    serviceVersion = ApiParseUtil.parseVersionString(nodes);
 
     // Look for h3 nodes
     // the pre following it is the definition
@@ -254,6 +247,8 @@ class Api extends Member with ApiParseUtil {
     gen.writeln('};');
     gen.writeln();
     gen.writeStatement('class VmService {');
+    gen.writeStatement("static const String generatedServiceVersion = '${serviceVersion}';");
+    gen.writeln();
     gen.writeStatement('StreamSubscription _streamSub;');
     gen.writeStatement('Function _writeMessage;');
     gen.writeStatement('int _id = 0;');

--- a/dart/tool/generate.dart
+++ b/dart/tool/generate.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:markdown/markdown.dart';
 import 'package:path/path.dart';
 
+import 'common/generate_common.dart';
 import 'dart/generate_dart.dart' as dart show Api, api, DartGenerator;
 import 'java/generate_java.dart' as java show Api, api, JavaGenerator;
 
@@ -20,6 +21,7 @@ main(List<String> args) {
   var document = new Document();
   var nodes = document.parseLines(file.readAsStringSync().split('\n'));
   print('Parsed ${file.path}.');
+  print('Service protocol version ${ApiParseUtil.parseVersionString(nodes)}.');
 
   // Generate code from the model.
   _generateDart(appDirPath, nodes);
@@ -27,6 +29,7 @@ main(List<String> args) {
 }
 
 void _generateDart(String appDirPath, List<Node> nodes) {
+  print('');
   var outDirPath = normalize(join(appDirPath, '..', 'lib'));
   var outDir = new Directory(outDirPath);
   if (!outDir.existsSync()) outDir.createSync(recursive: true);
@@ -41,11 +44,12 @@ void _generateDart(String appDirPath, List<Node> nodes) {
 }
 
 void _generateJava(String appDirPath, List<Node> nodes) {
+  print('');
   var srcDirPath = normalize(join(appDirPath, '..', '..', 'java', 'src'));
   assert(new Directory(srcDirPath).existsSync());
   var generator = new java.JavaGenerator(srcDirPath);
   java.api = new java.Api();
   java.api.parse(nodes);
   java.api.generate(generator);
-  print('Wrote Java to $srcDirPath');
+  print('Wrote Java to $srcDirPath.');
 }

--- a/dart/tool/service.md
+++ b/dart/tool/service.md
@@ -1,8 +1,8 @@
-# Dart VM Service Protocol 2.0
+# Dart VM Service Protocol 2.0.0
 
 > Please post feedback to the [observatory-discuss group][discuss-list]
 
-This document describes of _version 2.0_ of the Dart VM Service Protocol. This
+This document describes of _version 2.0.0_ of the Dart VM Service Protocol. This
 protocol is used to communicate with a running Dart Virtual Machine.
 
 To use the Service Protocol, start the VM with the *--observe* flag.


### PR DESCRIPTION
Include the protocol version in the generated code as `generatedServiceVersion`. Clients can then choose to parse it as a semver number, if desired.

@danrubel 