### PR TITLE
gen the version into the pubspec

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 0.1.0
+## 2.0.0
+- Upgraded the library to the 2.0 version of the service protocol
 
+## 0.1.0
 - Copied basic Dart API generator from Atom Dart Plugin
     https://github.com/dart-atom/dartlang/tree/master/tool
 - Refactored Dart code to generate Java client as well as Dart client
-

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -6,6 +6,8 @@ library vm_service_lib;
 import 'dart:async';
 import 'dart:convert' show JSON, JsonCodec;
 
+const String vmServiceVersion = '2.0.0';
+
 /// @optional
 const String optional = 'optional';
 
@@ -58,8 +60,6 @@ Map<String, Function> _typeFactories = {
 };
 
 class VmService {
-  static const String generatedServiceVersion = '2.0.0';
-
   StreamSubscription _streamSub;
   Function _writeMessage;
   int _id = 0;

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 0.1.0
+version: 2.0.0
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers

--- a/dart/tool/common/generate_common.dart
+++ b/dart/tool/common/generate_common.dart
@@ -12,7 +12,10 @@ import 'src_gen_common.dart';
 /// [ApiParseUtil] contains top level parsing utilities.
 class ApiParseUtil {
   /// Extract the current VM Service version number as a String.
-  static String parseVersionString(List<Node> nodes) {
+  static String parseVersionString(List<Node> nodes) =>
+      parseVersionSemVer(nodes).toString();
+
+  static Version parseVersionSemVer(List<Node> nodes) {
     final RegExp regex = new RegExp(r'[\d.]+');
 
     // Extract version from header: `# Dart VM Service Protocol 2.0`.
@@ -24,11 +27,7 @@ class ApiParseUtil {
     // Append a `.0`.
     String ver = '${match.group(0)}.0';
 
-    // Ensure that the version parses; this will throw a FormatException on
-    // parse errors.
-    new Version.parse(ver);
-
-    return ver;
+    return new Version.parse(ver);
   }
 
   /// Extract the current VM Service version number.

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -34,9 +34,6 @@ library vm_service_lib;
 import 'dart:async';
 import 'dart:convert' show JSON, JsonCodec;
 
-/// @optional
-const String optional = 'optional';
-
 ''';
 
 final String _implCode = r'''
@@ -238,17 +235,19 @@ class Api extends Member with ApiParseUtil {
 
   void generate(DartGenerator gen) {
     gen.out(_headerCode);
+    gen.writeln("const String vmServiceVersion = '${serviceVersion}';");
+    gen.writeln();
+    gen.writeln('/// @optional');
+    gen.writeln("const String optional = 'optional';");
+    gen.writeln();
     gen.write('Map<String, Function> _typeFactories = {');
     types.forEach((Type type) {
-      //if (type.isResponse)
       gen.write("'${type.rawName}': ${type.name}.parse");
       gen.writeln(type == types.last ? '' : ',');
     });
     gen.writeln('};');
     gen.writeln();
     gen.writeStatement('class VmService {');
-    gen.writeStatement("static const String generatedServiceVersion = '${serviceVersion}';");
-    gen.writeln();
     gen.writeStatement('StreamSubscription _streamSub;');
     gen.writeStatement('Function _writeMessage;');
     gen.writeStatement('int _id = 0;');


### PR DESCRIPTION
Fix https://github.com/dart-lang/vm_service_drivers/issues/28. Generate the protocol version into the pubspec; validate the the changelog has an entry for that protocol version. When updating the pubspec, preserve existing patch and build info (so from x.y.z-foo, preserve z and foo).

@danrubel 