### PR TITLE
tweaks to how the javadoc prints out

### DIFF
--- a/dart/tool/java/generate_java.dart
+++ b/dart/tool/java/generate_java.dart
@@ -13,6 +13,8 @@ import 'src_gen_java.dart';
 
 export 'src_gen_java.dart' show JavaGenerator;
 
+const String servicePackage = 'org.dartlang.vm.service';
+
 Api api;
 
 String _coerceRefType(String typeName) {
@@ -85,11 +87,11 @@ class Api extends Member with ApiParseUtil {
       }
     }
 
-    gen.writeType('org.dartlang.vm.service.VmService', (TypeWriter writer) {
+    gen.writeType('$servicePackage.VmService', (TypeWriter writer) {
       writer.addImport('com.google.gson.JsonObject');
-      writer.addImport('org.dartlang.vm.service.consumer.*');
-      writer.addImport('org.dartlang.vm.service.element.*');
-      writer.superclassName = 'org.dartlang.vm.service.VmServiceBase';
+      writer.addImport('$servicePackage.consumer.*');
+      writer.addImport('$servicePackage.element.*');
+      writer.superclassName = '$servicePackage.VmServiceBase';
       writer.addField('versionMajor', 'int',
           modifiers: 'public static final',
           value: '$serviceMajor',
@@ -227,7 +229,7 @@ class Enum extends Member {
     _parse(new Tokenizer(definition).tokenize());
   }
 
-  String get elementTypeName => 'org.dartlang.vm.service.element.$name';
+  String get elementTypeName => '$servicePackage.element.$name';
 
   void generateEnum(JavaGenerator gen) {
     gen.writeType(elementTypeName, (TypeWriter writer) {
@@ -352,7 +354,7 @@ class Method extends Member {
     } else {
       prefix = returnType.types.first.javaBoxedName;
     }
-    return 'org.dartlang.vm.service.consumer.${prefix}Consumer';
+    return '$servicePackage.consumer.${prefix}Consumer';
   }
 
   bool get hasArgs => args.isNotEmpty;
@@ -362,7 +364,7 @@ class Method extends Member {
   void generateConsumerInterface(JavaGenerator gen) {
     gen.writeType(consumerTypeName, (TypeWriter writer) {
       writer.javadoc = returnType.docs;
-      writer.interfaceNames.add('org.dartlang.vm.service.consumer.Consumer');
+      writer.interfaceNames.add('$servicePackage.consumer.Consumer');
       writer.isInterface = true;
       for (var t in returnType.types) {
         writer.addImport(t.elementTypeName);
@@ -559,7 +561,7 @@ class Type extends Member {
   }
 
   void generateElement(JavaGenerator gen) {
-    gen.writeType('org.dartlang.vm.service.element.$name', (TypeWriter writer) {
+    gen.writeType('$servicePackage.element.$name', (TypeWriter writer) {
       if (fields.any((f) => f.type.types.any((t) => t.isArray))) {
         writer.addImport('com.google.gson.JsonObject');
       }
@@ -660,8 +662,8 @@ class TypeField extends Member {
   String get docs {
     String str = _docs == null ? '' : _docs;
     if (type.isMultipleReturns) {
-      str += '\n\n[${generatableName}] can be one of '
-          '${joinLast(type.types.map((t) => '[${t}]'), ', ', ' or ')}.';
+      str += '\n\n@return one of '
+          '${joinLast(type.types.map((t) => '<code>${t}</code>'), ', ', ' or ')}';
       str = str.trim();
     }
     return str;
@@ -741,7 +743,7 @@ class TypeRef {
 
   String get elementTypeName {
     if (isSimple) return null;
-    return 'org.dartlang.vm.service.element.$name';
+    return '$servicePackage.element.$name';
   }
 
   bool get isArray => arrayDepth > 0;

--- a/dart/tool/java/src_gen_java.dart
+++ b/dart/tool/java/src_gen_java.dart
@@ -12,7 +12,7 @@ import 'package:path/path.dart';
 import '../common/src_gen_common.dart';
 
 /// The maximum length for javadoc comments.
-int colBoundary = 80;
+int colBoundary = 100;
 
 /// The header for every generated file.
 String fileHeader;

--- a/java/src/org/dartlang/vm/service/VmService.java
+++ b/java/src/org/dartlang/vm/service/VmService.java
@@ -32,8 +32,7 @@ public class VmService extends VmServiceBase {
   public static final int versionMinor = 0;
 
   /**
-   * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of
-   * some script.
+   * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.
    */
   public void addBreakpoint(String isolateId, String scriptId, int line, BreakpointConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -44,8 +43,7 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [addBreakpointAtEntry] RPC is used to add a breakpoint at the
-   * entrypoint of some function.
+   * The [addBreakpointAtEntry] RPC is used to add a breakpoint at the entrypoint of some function.
    */
   public void addBreakpointAtEntry(String isolateId, String functionId, BreakpointConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -55,8 +53,7 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [evaluate] RPC is used to evaluate an expression in the context of
-   * some target.
+   * The [evaluate] RPC is used to evaluate an expression in the context of some target.
    */
   public void evaluate(String isolateId, String targetId, String expression, EvaluateConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -67,9 +64,9 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [evaluateInFrame] RPC is used to evaluate an expression in the context
-   * of a particular stack frame. [frameIndex] is the index of the desired
-   * Frame, with an index of [0] indicating the top (most recent) frame.
+   * The [evaluateInFrame] RPC is used to evaluate an expression in the context of a particular
+   * stack frame. [frameIndex] is the index of the desired Frame, with an index of [0] indicating
+   * the top (most recent) frame.
    */
   public void evaluateInFrame(String isolateId, int frameIndex, String expression, EvaluateInFrameConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -80,8 +77,8 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The _getFlagList RPC returns a list of all command line flags in the VM
-   * along with their current values.
+   * The _getFlagList RPC returns a list of all command line flags in the VM along with their
+   * current values.
    */
   public void getFlagList(FlagListConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -98,8 +95,7 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [getObject] RPC is used to lookup an [object] from some isolate by its
-   * [id].
+   * The [getObject] RPC is used to lookup an [object] from some isolate by its [id].
    */
   public void getObject(String isolateId, String objectId, GetObjectConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -109,8 +105,8 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [getStack] RPC is used to retrieve the current execution stack and
-   * message queue for an isolate. The isolate does not need to be paused.
+   * The [getStack] RPC is used to retrieve the current execution stack and message queue for an
+   * isolate. The isolate does not need to be paused.
    */
   public void getStack(String isolateId, StackConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -127,8 +123,8 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [getVersion] RPC is used to determine what version of the Service
-   * Protocol is served by a VM.
+   * The [getVersion] RPC is used to determine what version of the Service Protocol is served by a
+   * VM.
    */
   public void getVersion(VersionConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -136,9 +132,8 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [pause] RPC is used to interrupt a running isolate. The RPC enqueues
-   * the interrupt request and potentially returns before the isolate is
-   * paused.
+   * The [pause] RPC is used to interrupt a running isolate. The RPC enqueues the interrupt request
+   * and potentially returns before the isolate is paused.
    */
   public void pause(String isolateId, SuccessConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -159,8 +154,8 @@ public class VmService extends VmServiceBase {
   /**
    * The [resume] RPC is used to resume execution of a paused isolate.
    * 
-   * @param step A [StepOption] indicates which form of stepping is requested
-   * in a resume RPC. This parameter is optional and may be null.
+   * @param step A [StepOption] indicates which form of stepping is requested in a resume RPC. This
+   * parameter is optional and may be null.
    */
   public void resume(String isolateId, StepOption step, SuccessConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -170,8 +165,8 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [setLibraryDebuggable] RPC is used to enable or disable whether
-   * breakpoints and stepping work for a given library.
+   * The [setLibraryDebuggable] RPC is used to enable or disable whether breakpoints and stepping
+   * work for a given library.
    */
   public void setLibraryDebuggable(String isolateId, String libraryId, boolean isDebuggable, SuccessConsumer consumer) {
     JsonObject params = new JsonObject();
@@ -201,8 +196,8 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [streamListen] RPC subscribes to a stream in the VM. Once subscribed,
-   * the client will begin receiving events from the stream.
+   * The [streamListen] RPC subscribes to a stream in the VM. Once subscribed, the client will
+   * begin receiving events from the stream.
    */
   public void streamListen(String streamId, SuccessConsumer consumer) {
     JsonObject params = new JsonObject();

--- a/java/src/org/dartlang/vm/service/element/BoundField.java
+++ b/java/src/org/dartlang/vm/service/element/BoundField.java
@@ -19,8 +19,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
- * A [BoundField] represents a field bound to a particular value in an
- * [Instance].
+ * A [BoundField] represents a field bound to a particular value in an [Instance].
  */
 public class BoundField extends Element {
 
@@ -33,7 +32,7 @@ public class BoundField extends Element {
   }
 
   /**
-   * [value] can be one of [InstanceRef] or [Sentinel].
+   * @return one of <code>InstanceRef</code> or <code>Sentinel</code>
    */
   public InstanceRef getValue() {
     JsonElement elem = json.get("value");

--- a/java/src/org/dartlang/vm/service/element/BoundVariable.java
+++ b/java/src/org/dartlang/vm/service/element/BoundVariable.java
@@ -19,8 +19,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
- * A [BoundVariable] represents a local variable bound to a particular value in
- * a [Frame].
+ * A [BoundVariable] represents a local variable bound to a particular value in a [Frame].
  */
 public class BoundVariable extends Element {
 
@@ -33,7 +32,7 @@ public class BoundVariable extends Element {
   }
 
   /**
-   * [value] can be one of [InstanceRef] or [Sentinel].
+   * @return one of <code>InstanceRef</code> or <code>Sentinel</code>
    */
   public InstanceRef getValue() {
     JsonElement elem = json.get("value");

--- a/java/src/org/dartlang/vm/service/element/Class.java
+++ b/java/src/org/dartlang/vm/service/element/Class.java
@@ -50,8 +50,7 @@ public class Class extends Element {
   }
 
   /**
-   * A list of functions in this class. Does not include functions from
-   * superclasses.
+   * A list of functions in this class. Does not include functions from superclasses.
    */
   public List<FuncRef> getFunctions() {
     JsonArray array = json.getAsJsonArray("functions");
@@ -64,8 +63,7 @@ public class Class extends Element {
   }
 
   /**
-   * A list of interface types for this class. The value will be of the kind:
-   * Type.
+   * A list of interface types for this class. The value will be of the kind: Type.
    */
   public List<InstanceRef> getInterfaces() {
     JsonArray array = json.getAsJsonArray("interfaces");

--- a/java/src/org/dartlang/vm/service/element/ContextElement.java
+++ b/java/src/org/dartlang/vm/service/element/ContextElement.java
@@ -25,7 +25,7 @@ public class ContextElement extends Element {
   }
 
   /**
-   * [value] can be one of [InstanceRef] or [Sentinel].
+   * @return one of <code>InstanceRef</code> or <code>Sentinel</code>
    */
   public InstanceRef getValue() {
     JsonElement elem = json.get("value");

--- a/java/src/org/dartlang/vm/service/element/Error.java
+++ b/java/src/org/dartlang/vm/service/element/Error.java
@@ -18,8 +18,7 @@ package org.dartlang.vm.service.element;
 import com.google.gson.JsonObject;
 
 /**
- * An [Error] represents a Dart language level error. This is distinct from an
- * rpc error.
+ * An [Error] represents a Dart language level error. This is distinct from an rpc error.
  */
 public class Error extends Element {
 
@@ -28,8 +27,7 @@ public class Error extends Element {
   }
 
   /**
-   * If this error is due to an unhandled exception, this is the exception
-   * thrown.
+   * If this error is due to an unhandled exception, this is the exception thrown.
    */
   public InstanceRef getException() {
     return new InstanceRef((JsonObject) json.get("exception"));
@@ -50,8 +48,7 @@ public class Error extends Element {
   }
 
   /**
-   * If this error is due to an unhandled exception, this is the stacktrace
-   * object.
+   * If this error is due to an unhandled exception, this is the stacktrace object.
    */
   public InstanceRef getStacktrace() {
     return new InstanceRef((JsonObject) json.get("stacktrace"));

--- a/java/src/org/dartlang/vm/service/element/ErrorKind.java
+++ b/java/src/org/dartlang/vm/service/element/ErrorKind.java
@@ -28,8 +28,7 @@ public enum ErrorKind {
   LanguageError,
 
   /**
-   * The isolate has encounted an internal error. These errors should be
-   * reported as bugs.
+   * The isolate has encounted an internal error. These errors should be reported as bugs.
    */
   InternalError,
 

--- a/java/src/org/dartlang/vm/service/element/Event.java
+++ b/java/src/org/dartlang/vm/service/element/Event.java
@@ -21,9 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * An [Event] is an asynchronous notification from the VM. It is delivered only
- * when the client has subscribed to an event stream using the streamListen
- * RPC.
+ * An [Event] is an asynchronous notification from the VM. It is delivered only when the client has
+ * subscribed to an event stream using the streamListen RPC.
  */
 public class Event extends Element {
 
@@ -32,25 +31,22 @@ public class Event extends Element {
   }
 
   /**
-   * The breakpoint which was added, removed, or resolved. This is provided for
-   * the event kinds: PauseBreakpoint BreakpointAdded BreakpointRemoved
-   * BreakpointResolved
+   * The breakpoint which was added, removed, or resolved. This is provided for the event kinds:
+   * PauseBreakpoint BreakpointAdded BreakpointRemoved BreakpointResolved
    */
   public Breakpoint getBreakpoint() {
     return new Breakpoint((JsonObject) json.get("breakpoint"));
   }
 
   /**
-   * An array of bytes, encoded as a base64 string. This is provided for the
-   * WriteEvent event.
+   * An array of bytes, encoded as a base64 string. This is provided for the WriteEvent event.
    */
   public String getBytes() {
     return json.get("bytes").getAsString();
   }
 
   /**
-   * The exception associated with this event, if this is a PauseException
-   * event.
+   * The exception associated with this event, if this is a PauseException event.
    */
   public InstanceRef getException() {
     return new InstanceRef((JsonObject) json.get("exception"));
@@ -71,12 +67,10 @@ public class Event extends Element {
   }
 
   /**
-   * The list of breakpoints at which we are currently paused for a
-   * PauseBreakpoint event. This list may be empty. For example, while
-   * single-stepping, the VM sends a PauseBreakpoint event with no breakpoints.
-   * If there is more than one breakpoint set at the program position, then all
-   * of them will be provided. This is provided for the event kinds:
-   * PauseBreakpoint
+   * The list of breakpoints at which we are currently paused for a PauseBreakpoint event. This
+   * list may be empty. For example, while single-stepping, the VM sends a PauseBreakpoint event
+   * with no breakpoints. If there is more than one breakpoint set at the program position, then
+   * all of them will be provided. This is provided for the event kinds: PauseBreakpoint
    */
   public List<Breakpoint> getPauseBreakpoints() {
     JsonArray array = json.getAsJsonArray("pauseBreakpoints");
@@ -89,21 +83,19 @@ public class Event extends Element {
   }
 
   /**
-   * The timestamp (in milliseconds since the epoch) associated with this
-   * event. For some isolate pause events, the timestamp is from when the
-   * isolate was paused. For other events, the timestamp is from when the event
-   * was created.
+   * The timestamp (in milliseconds since the epoch) associated with this event. For some isolate
+   * pause events, the timestamp is from when the isolate was paused. For other events, the
+   * timestamp is from when the event was created.
    */
   public int getTimestamp() {
     return json.get("timestamp").getAsInt();
   }
 
   /**
-   * The top stack frame associated with this event, if applicable. This is
-   * provided for the event kinds: PauseBreakpoint PauseInterrupted
-   * PauseException For the Resume event, the top frame is provided at all
-   * times except for the initial resume event that is delivered when an
-   * isolate begins execution.
+   * The top stack frame associated with this event, if applicable. This is provided for the event
+   * kinds: PauseBreakpoint PauseInterrupted PauseException For the Resume event, the top frame is
+   * provided at all times except for the initial resume event that is delivered when an isolate
+   * begins execution.
    */
   public Frame getTopFrame() {
     return new Frame((JsonObject) json.get("topFrame"));

--- a/java/src/org/dartlang/vm/service/element/EventKind.java
+++ b/java/src/org/dartlang/vm/service/element/EventKind.java
@@ -16,8 +16,8 @@ package org.dartlang.vm.service.element;
 // This is a generated file.
 
 /**
- * Adding new values to [EventKind] is considered a backwards compatible
- * change. Clients should ignore unrecognized events.
+ * Adding new values to [EventKind] is considered a backwards compatible change. Clients should
+ * ignore unrecognized events.
  */
 public enum EventKind {
 
@@ -37,8 +37,8 @@ public enum EventKind {
   IsolateExit,
 
   /**
-   * Notification that isolate identifying information has changed. Currently
-   * used to notify of changes to the isolate debugging name via setName.
+   * Notification that isolate identifying information has changed. Currently used to notify of
+   * changes to the isolate debugging name via setName.
    */
   IsolateUpdate,
 

--- a/java/src/org/dartlang/vm/service/element/Field.java
+++ b/java/src/org/dartlang/vm/service/element/Field.java
@@ -27,8 +27,8 @@ public class Field extends Element {
   }
 
   /**
-   * The declared type of this field. The value will always be of one of the
-   * kinds: Type, TypeRef, TypeParameter, BoundedType.
+   * The declared type of this field. The value will always be of one of the kinds: Type, TypeRef,
+   * TypeParameter, BoundedType.
    */
   public InstanceRef getDeclaredType() {
     return new InstanceRef((JsonObject) json.get("declaredType"));

--- a/java/src/org/dartlang/vm/service/element/FieldRef.java
+++ b/java/src/org/dartlang/vm/service/element/FieldRef.java
@@ -27,8 +27,8 @@ public class FieldRef extends Element {
   }
 
   /**
-   * The declared type of this field. The value will always be of one of the
-   * kinds: Type, TypeRef, TypeParameter, BoundedType.
+   * The declared type of this field. The value will always be of one of the kinds: Type, TypeRef,
+   * TypeParameter, BoundedType.
    */
   public InstanceRef getDeclaredType() {
     return new InstanceRef((JsonObject) json.get("declaredType"));

--- a/java/src/org/dartlang/vm/service/element/Flag.java
+++ b/java/src/org/dartlang/vm/service/element/Flag.java
@@ -48,8 +48,8 @@ public class Flag extends Element {
   }
 
   /**
-   * The value of this flag as a string. If this property is absent, then the
-   * value of the flag was NULL.
+   * The value of this flag as a string. If this property is absent, then the value of the flag was
+   * NULL.
    */
   public String getValueAsString() {
     return json.get("valueAsString").getAsString();

--- a/java/src/org/dartlang/vm/service/element/Instance.java
+++ b/java/src/org/dartlang/vm/service/element/Instance.java
@@ -44,19 +44,18 @@ public class Instance extends Element {
   }
 
   /**
-   * The bound of a TypeParameter or BoundedType. The value will always be of
-   * one of the kinds: Type, TypeRef, TypeParameter, BoundedType. Provided for
-   * instance kinds: BoundedType TypeParameter
+   * The bound of a TypeParameter or BoundedType. The value will always be of one of the kinds:
+   * Type, TypeRef, TypeParameter, BoundedType. Provided for instance kinds: BoundedType
+   * TypeParameter
    */
   public InstanceRef getBound() {
     return new InstanceRef((JsonObject) json.get("bound"));
   }
 
   /**
-   * The bytes of a TypedData instance. Provided for instance kinds:
-   * Uint8ClampedList Uint8List Uint16List Uint32List Uint64List Int8List
-   * Int16List Int32List Int64List Float32List Float64List Int32x4List
-   * Float32x4List Float64x2List
+   * The bytes of a TypedData instance. Provided for instance kinds: Uint8ClampedList Uint8List
+   * Uint16List Uint32List Uint64List Int8List Int16List Int32List Int64List Float32List
+   * Float64List Int32x4List Float32x4List Float64x2List
    */
   public List<Integer> getBytes() {
     return getListInt("bytes");
@@ -70,16 +69,14 @@ public class Instance extends Element {
   }
 
   /**
-   * The context associated with a Closure instance. Provided for instance
-   * kinds: Closure
+   * The context associated with a Closure instance. Provided for instance kinds: Closure
    */
   public FuncRef getClosureContext() {
     return new FuncRef((JsonObject) json.get("closureContext"));
   }
 
   /**
-   * The function associated with a Closure instance. Provided for instance
-   * kinds: Closure
+   * The function associated with a Closure instance. Provided for instance kinds: Closure
    */
   public FuncRef getClosureFunction() {
     return new FuncRef((JsonObject) json.get("closureFunction"));
@@ -88,7 +85,7 @@ public class Instance extends Element {
   /**
    * The elements of a List instance. Provided for instance kinds: List
    * 
-   * [elements] can be one of [InstanceRef] or [List<Sentinel>].
+   * @return one of <code>InstanceRef</code> or <code>List<Sentinel></code>
    */
   public InstanceRef getElements() {
     JsonElement elem = json.get("elements");
@@ -107,16 +104,14 @@ public class Instance extends Element {
   }
 
   /**
-   * Whether this regular expression is case sensitive. Provided for instance
-   * kinds: RegExp
+   * Whether this regular expression is case sensitive. Provided for instance kinds: RegExp
    */
   public boolean getIsCaseSensitive() {
     return json.get("isCaseSensitive").getAsBoolean();
   }
 
   /**
-   * Whether this regular expression matches multiple lines. Provided for
-   * instance kinds: RegExp
+   * Whether this regular expression matches multiple lines. Provided for instance kinds: RegExp
    */
   public boolean getIsMultiLine() {
     return json.get("isMultiLine").getAsBoolean();
@@ -130,18 +125,16 @@ public class Instance extends Element {
   }
 
   /**
-   * The length of a List instance. Provided for instance kinds: List Map
-   * Uint8ClampedList Uint8List Uint16List Uint32List Uint64List Int8List
-   * Int16List Int32List Int64List Float32List Float64List Int32x4List
-   * Float32x4List Float64x2List
+   * The length of a List instance. Provided for instance kinds: List Map Uint8ClampedList
+   * Uint8List Uint16List Uint32List Uint64List Int8List Int16List Int32List Int64List Float32List
+   * Float64List Int32x4List Float32x4List Float64x2List
    */
   public int getLength() {
     return json.get("length").getAsInt();
   }
 
   /**
-   * The referent of a MirrorReference instance. Provided for instance kinds:
-   * MirrorReference
+   * The referent of a MirrorReference instance. Provided for instance kinds: MirrorReference
    */
   public InstanceRef getMirrorReferent() {
     return new InstanceRef((JsonObject) json.get("mirrorReferent"));
@@ -155,16 +148,14 @@ public class Instance extends Element {
   }
 
   /**
-   * The index of a TypeParameter instance. Provided for instance kinds:
-   * TypeParameter
+   * The index of a TypeParameter instance. Provided for instance kinds: TypeParameter
    */
   public int getParameterIndex() {
     return json.get("parameterIndex").getAsInt();
   }
 
   /**
-   * The parameterized class of a type parameter: Provided for instance kinds:
-   * TypeParameter
+   * The parameterized class of a type parameter: Provided for instance kinds: TypeParameter
    */
   public ClassRef getParameterizedClass() {
     return new ClassRef((JsonObject) json.get("parameterizedClass"));
@@ -178,26 +169,23 @@ public class Instance extends Element {
   }
 
   /**
-   * The key for a WeakProperty instance. Provided for instance kinds:
-   * WeakProperty
+   * The key for a WeakProperty instance. Provided for instance kinds: WeakProperty
    */
   public InstanceRef getPropertyKey() {
     return new InstanceRef((JsonObject) json.get("propertyKey"));
   }
 
   /**
-   * The key for a WeakProperty instance. Provided for instance kinds:
-   * WeakProperty
+   * The key for a WeakProperty instance. Provided for instance kinds: WeakProperty
    */
   public InstanceRef getPropertyValue() {
     return new InstanceRef((JsonObject) json.get("propertyValue"));
   }
 
   /**
-   * The type bounded by a BoundedType instance - or - the referent of a
-   * TypeRef instance. The value will always be of one of the kinds: Type,
-   * TypeRef, TypeParameter, BoundedType. Provided for instance kinds:
-   * BoundedType TypeRef
+   * The type bounded by a BoundedType instance - or - the referent of a TypeRef instance. The
+   * value will always be of one of the kinds: Type, TypeRef, TypeParameter, BoundedType. Provided
+   * for instance kinds: BoundedType TypeRef
    */
   public InstanceRef getTargetType() {
     return new InstanceRef((JsonObject) json.get("targetType"));
@@ -211,25 +199,24 @@ public class Instance extends Element {
   }
 
   /**
-   * The corresponding Class if this Type is canonical. Provided for instance
-   * kinds: Type
+   * The corresponding Class if this Type is canonical. Provided for instance kinds: Type
    */
   public ClassRef getTypeClass() {
     return new ClassRef((JsonObject) json.get("typeClass"));
   }
 
   /**
-   * The value of this instance as a string. Provided for the instance kinds:
-   * Bool (true or false) Double (suitable for passing to Double.parse()) Int
-   * (suitable for passing to int.parse()) String (value may be truncated)
+   * The value of this instance as a string. Provided for the instance kinds: Bool (true or false)
+   * Double (suitable for passing to Double.parse()) Int (suitable for passing to int.parse())
+   * String (value may be truncated)
    */
   public String getValueAsString() {
     return json.get("valueAsString").getAsString();
   }
 
   /**
-   * The valueAsString for String references may be truncated. If so, this
-   * property is added with the value 'true'.
+   * The valueAsString for String references may be truncated. If so, this property is added with
+   * the value 'true'.
    */
   public boolean getValueAsStringIsTruncated() {
     return json.get("valueAsStringIsTruncated").getAsBoolean();

--- a/java/src/org/dartlang/vm/service/element/InstanceKind.java
+++ b/java/src/org/dartlang/vm/service/element/InstanceKind.java
@@ -16,8 +16,8 @@ package org.dartlang.vm.service.element;
 // This is a generated file.
 
 /**
- * Adding new values to [InstanceKind] is considered a backwards compatible
- * change. Clients should treat unrecognized instance kinds as [PlainInstance].
+ * Adding new values to [InstanceKind] is considered a backwards compatible change. Clients should
+ * treat unrecognized instance kinds as [PlainInstance].
  */
 public enum InstanceKind {
 
@@ -52,14 +52,12 @@ public enum InstanceKind {
   String,
 
   /**
-   * An instance of the built-in VM List implementation. User-defined Lists
-   * will be PlainInstance.
+   * An instance of the built-in VM List implementation. User-defined Lists will be PlainInstance.
    */
   List,
 
   /**
-   * An instance of the built-in VM Map implementation. User-defined Maps will
-   * be PlainInstance.
+   * An instance of the built-in VM Map implementation. User-defined Maps will be PlainInstance.
    */
   Map,
 
@@ -73,8 +71,8 @@ public enum InstanceKind {
   Int32x4,
 
   /**
-   * An instance of the built-in VM TypedData implementations. User-defined
-   * TypedDatas will be PlainInstance.
+   * An instance of the built-in VM TypedData implementations. User-defined TypedDatas will be
+   * PlainInstance.
    */
   Uint8ClampedList,
 
@@ -110,8 +108,8 @@ public enum InstanceKind {
   StackTrace,
 
   /**
-   * An instance of the built-in VM Closure implementation. User-defined
-   * Closures will be PlainInstance.
+   * An instance of the built-in VM Closure implementation. User-defined Closures will be
+   * PlainInstance.
    */
   Closure,
 

--- a/java/src/org/dartlang/vm/service/element/InstanceRef.java
+++ b/java/src/org/dartlang/vm/service/element/InstanceRef.java
@@ -41,10 +41,9 @@ public class InstanceRef extends Element {
   }
 
   /**
-   * The length of a List instance. Provided for instance kinds: List Map
-   * Uint8ClampedList Uint8List Uint16List Uint32List Uint64List Int8List
-   * Int16List Int32List Int64List Float32List Float64List Int32x4List
-   * Float32x4List Float64x2List
+   * The length of a List instance. Provided for instance kinds: List Map Uint8ClampedList
+   * Uint8List Uint16List Uint32List Uint64List Int8List Int16List Int32List Int64List Float32List
+   * Float64List Int32x4List Float32x4List Float64x2List
    */
   public int getLength() {
     return json.get("length").getAsInt();
@@ -58,8 +57,7 @@ public class InstanceRef extends Element {
   }
 
   /**
-   * The parameterized class of a type parameter: Provided for instance kinds:
-   * TypeParameter
+   * The parameterized class of a type parameter: Provided for instance kinds: TypeParameter
    */
   public ClassRef getParameterizedClass() {
     return new ClassRef((JsonObject) json.get("parameterizedClass"));
@@ -73,26 +71,24 @@ public class InstanceRef extends Element {
   }
 
   /**
-   * The corresponding Class if this Type is canonical. Provided for instance
-   * kinds: Type
+   * The corresponding Class if this Type is canonical. Provided for instance kinds: Type
    */
   public ClassRef getTypeClass() {
     return new ClassRef((JsonObject) json.get("typeClass"));
   }
 
   /**
-   * The value of this instance as a string. Provided for the instance kinds:
-   * Null (null) Bool (true or false) Double (suitable for passing to
-   * Double.parse()) Int (suitable for passing to int.parse()) String (value
-   * may be truncated) Float32x4 Float64x2 Int32x4 StackTrace
+   * The value of this instance as a string. Provided for the instance kinds: Null (null) Bool
+   * (true or false) Double (suitable for passing to Double.parse()) Int (suitable for passing to
+   * int.parse()) String (value may be truncated) Float32x4 Float64x2 Int32x4 StackTrace
    */
   public String getValueAsString() {
     return json.get("valueAsString").getAsString();
   }
 
   /**
-   * The valueAsString for String references may be truncated. If so, this
-   * property is added with the value 'true'.
+   * The valueAsString for String references may be truncated. If so, this property is added with
+   * the value 'true'.
    */
   public boolean getValueAsStringIsTruncated() {
     return json.get("valueAsStringIsTruncated").getAsBoolean();

--- a/java/src/org/dartlang/vm/service/element/Isolate.java
+++ b/java/src/org/dartlang/vm/service/element/Isolate.java
@@ -43,8 +43,8 @@ public class Isolate extends Element {
   }
 
   /**
-   * The entry function for this isolate. Guaranteed to be initialized when the
-   * IsolateRunnable event fires.
+   * The entry function for this isolate. Guaranteed to be initialized when the IsolateRunnable
+   * event fires.
    */
   public FuncRef getEntry() {
     return new FuncRef((JsonObject) json.get("entry"));
@@ -65,8 +65,8 @@ public class Isolate extends Element {
   }
 
   /**
-   * A list of all libraries for this isolate. Guaranteed to be initialized
-   * when the IsolateRunnable event fires.
+   * A list of all libraries for this isolate. Guaranteed to be initialized when the
+   * IsolateRunnable event fires.
    */
   public List<LibraryRef> getLibraries() {
     JsonArray array = json.getAsJsonArray("libraries");
@@ -100,8 +100,8 @@ public class Isolate extends Element {
   }
 
   /**
-   * The last pause event delivered to the isolate. If the isolate is running,
-   * this will be a resume event.
+   * The last pause event delivered to the isolate. If the isolate is running, this will be a
+   * resume event.
    */
   public Event getPauseEvent() {
     return new Event((JsonObject) json.get("pauseEvent"));
@@ -115,16 +115,16 @@ public class Isolate extends Element {
   }
 
   /**
-   * The root library for this isolate. Guaranteed to be initialized when the
-   * IsolateRunnable event fires.
+   * The root library for this isolate. Guaranteed to be initialized when the IsolateRunnable event
+   * fires.
    */
   public LibraryRef getRootLib() {
     return new LibraryRef((JsonObject) json.get("rootLib"));
   }
 
   /**
-   * The time that the VM started in milliseconds since the epoch. Suitable to
-   * pass to DateTime.fromMillisecondsSinceEpoch.
+   * The time that the VM started in milliseconds since the epoch. Suitable to pass to
+   * DateTime.fromMillisecondsSinceEpoch.
    */
   public int getStartTime() {
     return json.get("startTime").getAsInt();

--- a/java/src/org/dartlang/vm/service/element/MapAssociation.java
+++ b/java/src/org/dartlang/vm/service/element/MapAssociation.java
@@ -25,7 +25,7 @@ public class MapAssociation extends Element {
   }
 
   /**
-   * [key] can be one of [InstanceRef] or [Sentinel].
+   * @return one of <code>InstanceRef</code> or <code>Sentinel</code>
    */
   public InstanceRef getKey() {
     JsonElement elem = json.get("key");
@@ -37,7 +37,7 @@ public class MapAssociation extends Element {
   }
 
   /**
-   * [value] can be one of [InstanceRef] or [Sentinel].
+   * @return one of <code>InstanceRef</code> or <code>Sentinel</code>
    */
   public InstanceRef getValue() {
     JsonElement elem = json.get("value");

--- a/java/src/org/dartlang/vm/service/element/Obj.java
+++ b/java/src/org/dartlang/vm/service/element/Obj.java
@@ -27,28 +27,27 @@ public class Obj extends Element {
   }
 
   /**
-   * If an object is allocated in the Dart heap, it will have a corresponding
-   * class object. The class of a non-instance is not a Dart class, but is
-   * instead an internal vm object. Moving an Object into or out of the heap is
-   * considered a backwards compatible change for types other than Instance.
+   * If an object is allocated in the Dart heap, it will have a corresponding class object. The
+   * class of a non-instance is not a Dart class, but is instead an internal vm object. Moving an
+   * Object into or out of the heap is considered a backwards compatible change for types other
+   * than Instance.
    */
   public ClassRef getClassRef() {
     return new ClassRef((JsonObject) json.get("class"));
   }
 
   /**
-   * A unique identifier for an Object. Passed to the getObject RPC to reload
-   * this Object. Some objects may get a new id when they are reloaded.
+   * A unique identifier for an Object. Passed to the getObject RPC to reload this Object. Some
+   * objects may get a new id when they are reloaded.
    */
   public String getId() {
     return json.get("id").getAsString();
   }
 
   /**
-   * The size of this object in the heap. If an object is not heap-allocated,
-   * then this field is omitted. Note that the size can be zero for some
-   * objects. In the current VM implementation, this occurs for small integers,
-   * which are stored entirely within their object pointers.
+   * The size of this object in the heap. If an object is not heap-allocated, then this field is
+   * omitted. Note that the size can be zero for some objects. In the current VM implementation,
+   * this occurs for small integers, which are stored entirely within their object pointers.
    */
   public int getSize() {
     return json.get("size").getAsInt();

--- a/java/src/org/dartlang/vm/service/element/ObjRef.java
+++ b/java/src/org/dartlang/vm/service/element/ObjRef.java
@@ -27,8 +27,7 @@ public class ObjRef extends Element {
   }
 
   /**
-   * A unique identifier for an Object. Passed to the getObject RPC to load
-   * this Object.
+   * A unique identifier for an Object. Passed to the getObject RPC to load this Object.
    */
   public String getId() {
     return json.get("id").getAsString();

--- a/java/src/org/dartlang/vm/service/element/Response.java
+++ b/java/src/org/dartlang/vm/service/element/Response.java
@@ -18,9 +18,8 @@ package org.dartlang.vm.service.element;
 import com.google.gson.JsonObject;
 
 /**
- * Every non-error response returned by the Service Protocol extends
- * [Response]. By using the [type] property, the client can determine which
- * type of response has been provided.
+ * Every non-error response returned by the Service Protocol extends [Response]. By using the
+ * [type] property, the client can determine which type of response has been provided.
  */
 public class Response extends Element {
 
@@ -29,8 +28,8 @@ public class Response extends Element {
   }
 
   /**
-   * Every response returned by the VM Service has the type property. This
-   * allows the client distinguish between different kinds of responses.
+   * Every response returned by the VM Service has the type property. This allows the client
+   * distinguish between different kinds of responses.
    */
   public String getType() {
     return json.get("type").getAsString();

--- a/java/src/org/dartlang/vm/service/element/Script.java
+++ b/java/src/org/dartlang/vm/service/element/Script.java
@@ -35,8 +35,8 @@ public class Script extends Element {
   }
 
   /**
-   * The source code for this script. For certain built-in scripts, this may be
-   * reconstructed without source comments.
+   * The source code for this script. For certain built-in scripts, this may be reconstructed
+   * without source comments.
    */
   public String getSource() {
     return json.get("source").getAsString();

--- a/java/src/org/dartlang/vm/service/element/SentinelKind.java
+++ b/java/src/org/dartlang/vm/service/element/SentinelKind.java
@@ -16,8 +16,7 @@ package org.dartlang.vm.service.element;
 // This is a generated file.
 
 /**
- * A [SentinelKind] is used to distinguish different kinds of [Sentinel]
- * objects.
+ * A [SentinelKind] is used to distinguish different kinds of [Sentinel] objects.
  */
 public enum SentinelKind {
 

--- a/java/src/org/dartlang/vm/service/element/SourceLocation.java
+++ b/java/src/org/dartlang/vm/service/element/SourceLocation.java
@@ -18,8 +18,7 @@ package org.dartlang.vm.service.element;
 import com.google.gson.JsonObject;
 
 /**
- * The [SourceLocation] class is used to designate a position or range in some
- * script.
+ * The [SourceLocation] class is used to designate a position or range in some script.
  */
 public class SourceLocation extends Element {
 

--- a/java/src/org/dartlang/vm/service/element/StepOption.java
+++ b/java/src/org/dartlang/vm/service/element/StepOption.java
@@ -16,8 +16,7 @@ package org.dartlang.vm.service.element;
 // This is a generated file.
 
 /**
- * A [StepOption] indicates which form of stepping is requested in a resume
- * RPC.
+ * A [StepOption] indicates which form of stepping is requested in a resume RPC.
  */
 public enum StepOption {
 

--- a/java/src/org/dartlang/vm/service/element/Success.java
+++ b/java/src/org/dartlang/vm/service/element/Success.java
@@ -18,8 +18,7 @@ package org.dartlang.vm.service.element;
 import com.google.gson.JsonObject;
 
 /**
- * The [Success] type is used to indicate that an operation completed
- * successfully.
+ * The [Success] type is used to indicate that an operation completed successfully.
  */
 public class Success extends Element {
 

--- a/java/src/org/dartlang/vm/service/element/TypeArguments.java
+++ b/java/src/org/dartlang/vm/service/element/TypeArguments.java
@@ -21,8 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * A [TypeArguments] object represents the type argument vector for some
- * instantiated generic type.
+ * A [TypeArguments] object represents the type argument vector for some instantiated generic type.
  */
 public class TypeArguments extends Element {
 
@@ -38,8 +37,8 @@ public class TypeArguments extends Element {
   }
 
   /**
-   * A list of types. The value will always be one of the kinds: Type, TypeRef,
-   * TypeParameter, BoundedType.
+   * A list of types. The value will always be one of the kinds: Type, TypeRef, TypeParameter,
+   * BoundedType.
    */
   public List<InstanceRef> getTypes() {
     JsonArray array = json.getAsJsonArray("types");

--- a/java/src/org/dartlang/vm/service/element/VM.java
+++ b/java/src/org/dartlang/vm/service/element/VM.java
@@ -61,8 +61,8 @@ public class VM extends Element {
   }
 
   /**
-   * The time that the VM started in milliseconds since the epoch. Suitable to
-   * pass to DateTime.fromMillisecondsSinceEpoch.
+   * The time that the VM started in milliseconds since the epoch. Suitable to pass to
+   * DateTime.fromMillisecondsSinceEpoch.
    */
   public int getStartTime() {
     return json.get("startTime").getAsInt();

--- a/java/src/org/dartlang/vm/service/element/Version.java
+++ b/java/src/org/dartlang/vm/service/element/Version.java
@@ -27,16 +27,16 @@ public class Version extends Element {
   }
 
   /**
-   * The major version number is incremented when the protocol is changed in a
-   * potentially incompatible way.
+   * The major version number is incremented when the protocol is changed in a potentially
+   * incompatible way.
    */
   public int getMajor() {
     return json.get("major").getAsInt();
   }
 
   /**
-   * The minor version number is incremented when the protocol is changed in a
-   * backwards compatible way.
+   * The minor version number is incremented when the protocol is changed in a backwards compatible
+   * way.
    */
   public int getMinor() {
     return json.get("minor").getAsInt();


### PR DESCRIPTION
Tweaks to how the javadoc prints out:
- ensure consistent formatting at 100 char line
- use `<code>` style for element refs instead of `[]` style

I'll re-sync this once https://github.com/dart-lang/vm_service_drivers/pull/36 lands. @danrubel 