### PR TITLE
sort method args

### DIFF
--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -684,6 +684,12 @@ class MethodParser extends Parser {
     }
 
     expect(')');
+
+    method.args.sort((MethodArg a, MethodArg b) {
+      if (!a.optional && b.optional) return -1;
+      if (a.optional && !b.optional) return 1;
+      return 0;
+    });
   }
 }
 


### PR DESCRIPTION
Sort method args so that non-optional ones are generated before optional ones. We translate the args to positional and named respectively; this ordering makes dart happier.

This will be important for the v3 version of the spec.

@danrubel 