### PR TITLE
Update timestamps to be compatible with both v2.0 and v3.0 - fixes #51

### DIFF
--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -272,8 +272,8 @@ class VmService {
       } else {
         _log.severe('unknown message type: ${message}');
       }
-    } catch (e) {
-      _log.severe('unable to decode message: ${message}, ${e}');
+    } catch (e, s) {
+      _log.severe('unable to decode message: ${message}, ${e}\n${s}');
     }
   }
 }
@@ -815,7 +815,7 @@ class Event extends Response {
   /// event. For some isolate pause events, the timestamp is from when the
   /// isolate was paused. For other events, the timestamp is from when the event
   /// was created.
-  int timestamp;
+  num timestamp;
 
   /// The breakpoint which was added, removed, or resolved. This is provided for
   /// the event kinds: PauseBreakpoint BreakpointAdded BreakpointRemoved
@@ -1301,7 +1301,7 @@ class Isolate extends Response {
 
   /// The time that the VM started in milliseconds since the epoch. Suitable to
   /// pass to DateTime.fromMillisecondsSinceEpoch.
-  int startTime;
+  num startTime;
 
   /// The number of live ports for this isolate.
   int livePorts;
@@ -1776,7 +1776,7 @@ class VM extends Response {
 
   /// The time that the VM started in milliseconds since the epoch. Suitable to
   /// pass to DateTime.fromMillisecondsSinceEpoch.
-  int startTime;
+  num startTime;
 
   /// A list of isolates running in the VM.
   List<IsolateRef> isolates;

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -102,8 +102,8 @@ final String _implCode = r'''
       } else {
         _log.severe('unknown message type: ${message}');
       }
-    } catch (e) {
-      _log.severe('unable to decode message: ${message}, ${e}');
+    } catch (e, s) {
+      _log.severe('unable to decode message: ${message}, ${e}\n${s}');
     }
   }
 ''';
@@ -420,7 +420,7 @@ class TypeRef {
 
   bool get isArray => arrayDepth > 0;
 
-  bool get isSimple => name == 'int' || name == 'String' || name == 'bool';
+  bool get isSimple => name == 'int' || name == 'num' || name == 'String' || name == 'bool';
 
   String toString() => ref;
 }

--- a/dart/tool/service.md
+++ b/dart/tool/service.md
@@ -962,7 +962,7 @@ class Event extends Response {
   // The timestamp (in milliseconds since the epoch) associated with this event.
   // For some isolate pause events, the timestamp is from when the isolate was
   // paused. For other events, the timestamp is from when the event was created.
-  int timestamp;
+  num timestamp;
 
   // The breakpoint which was added, removed, or resolved.
   //
@@ -1599,7 +1599,7 @@ class Isolate extends Response {
   // The time that the VM started in milliseconds since the epoch.
   //
   // Suitable to pass to DateTime.fromMillisecondsSinceEpoch.
-  int startTime;
+  num startTime;
 
   // The number of live ports for this isolate.
   int livePorts;
@@ -2008,7 +2008,7 @@ class VM extends Response {
   // The time that the VM started in milliseconds since the epoch.
   //
   // Suitable to pass to DateTime.fromMillisecondsSinceEpoch.
-  int startTime;
+  num startTime;
 
   // A list of isolates running in the VM.
   @Isolate[] isolates;

--- a/java/src/org/dartlang/vm/service/element/Event.java
+++ b/java/src/org/dartlang/vm/service/element/Event.java
@@ -17,6 +17,7 @@ package org.dartlang.vm.service.element;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import java.math.BigDecimal;
 
 /**
  * An [Event] is an asynchronous notification from the VM. It is delivered only when the client has
@@ -84,8 +85,8 @@ public class Event extends Response {
    * pause events, the timestamp is from when the isolate was paused. For other events, the
    * timestamp is from when the event was created.
    */
-  public int getTimestamp() {
-    return json.get("timestamp").getAsInt();
+  public BigDecimal getTimestamp() {
+    return json.get("timestamp").getAsBigDecimal();
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/Isolate.java
+++ b/java/src/org/dartlang/vm/service/element/Isolate.java
@@ -17,6 +17,7 @@ package org.dartlang.vm.service.element;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import java.math.BigDecimal;
 
 /**
  * An [Isolate] object provides information about one isolate in the VM.
@@ -122,7 +123,7 @@ public class Isolate extends Response {
    * The time that the VM started in milliseconds since the epoch. Suitable to pass to
    * DateTime.fromMillisecondsSinceEpoch.
    */
-  public int getStartTime() {
-    return json.get("startTime").getAsInt();
+  public BigDecimal getStartTime() {
+    return json.get("startTime").getAsBigDecimal();
   }
 }

--- a/java/src/org/dartlang/vm/service/element/VM.java
+++ b/java/src/org/dartlang/vm/service/element/VM.java
@@ -17,6 +17,7 @@ package org.dartlang.vm.service.element;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import java.math.BigDecimal;
 
 public class VM extends Response {
 
@@ -61,8 +62,8 @@ public class VM extends Response {
    * The time that the VM started in milliseconds since the epoch. Suitable to pass to
    * DateTime.fromMillisecondsSinceEpoch.
    */
-  public int getStartTime() {
-    return json.get("startTime").getAsInt();
+  public BigDecimal getStartTime() {
+    return json.get("startTime").getAsBigDecimal();
   }
 
   /**


### PR DESCRIPTION
@devoncarew Timestamps in v2.x were int while in v3.0 they are double.