### PR TITLE
Tweak port # to keep travis build system happy

### DIFF
--- a/java/test/org/dartlang/vm/service/VmServiceTest.java
+++ b/java/test/org/dartlang/vm/service/VmServiceTest.java
@@ -202,7 +202,7 @@ public class VmServiceTest {
     new SampleOutPrinter("Version", process.getErrorStream());
 
     // Hardcode port to keep travis happy
-    vmPort = 7575;
+    vmPort = 7576;
     processArgs = new ArrayList<String>();
     processArgs.add(dartVm.getAbsolutePath());
     processArgs.add("--pause_isolates_on_start");


### PR DESCRIPTION
@devoncarew Travis periodically fails indicating that it cannot connect to the VM. Since the Dart client test and the Java client test use the same port, I suspect a race condition where the Dart client test is sometimes still holding onto the port when the Java client test requests it. This switches the Java client to use port 7576.