### PR TITLE
fix a bug with the ServiceExtensionAdded event

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.2
+- fixed a bug with the `ServiceExtensionAdded` event
+
 ## 0.1.1
 - expose the new 'Extension' event information
 

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -135,7 +135,7 @@ class VmService {
   // VMUpdate
   Stream<Event> get onVMEvent => _getEventController('VM').stream;
 
-  // IsolateStart, IsolateRunnable, IsolateExit, IsolateUpdate
+  // IsolateStart, IsolateRunnable, IsolateExit, IsolateUpdate, ServiceExtensionAdded
   Stream<Event> get onIsolateEvent => _getEventController('Isolate').stream;
 
   // PauseStart, PauseExit, PauseBreakpoint, PauseInterrupted, PauseException,
@@ -150,10 +150,6 @@ class VmService {
 
   // WriteEvent
   Stream<Event> get onStderrEvent => _getEventController('Stderr').stream;
-
-  // ServiceExtensionAdded
-  Stream<Event> get onServiceExtensionAddedEvent =>
-      _getEventController('ServiceExtensionAdded').stream;
 
   // Extension
   Stream<Event> get onExtensionEvent => _getEventController('Extension').stream;

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 0.1.1
+version: 0.1.2
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -333,7 +333,7 @@ VmService(Stream<String> inStream, void writeMessage(String message), {Log log})
 // VMUpdate
 Stream<Event> get onVMEvent => _getEventController('VM').stream;
 
-// IsolateStart, IsolateRunnable, IsolateExit, IsolateUpdate
+// IsolateStart, IsolateRunnable, IsolateExit, IsolateUpdate, ServiceExtensionAdded
 Stream<Event> get onIsolateEvent => _getEventController('Isolate').stream;
 
 // PauseStart, PauseExit, PauseBreakpoint, PauseInterrupted, PauseException,
@@ -348,9 +348,6 @@ Stream<Event> get onStdoutEvent => _getEventController('Stdout').stream;
 
 // WriteEvent
 Stream<Event> get onStderrEvent => _getEventController('Stderr').stream;
-
-// ServiceExtensionAdded
-Stream<Event> get onServiceExtensionAddedEvent => _getEventController('ServiceExtensionAdded').stream;
 
 // Extension
 Stream<Event> get onExtensionEvent => _getEventController('Extension').stream;


### PR DESCRIPTION
- fix a bug with the ServiceExtensionAdded event - we should not have exposed a separate `onServiceExtensionAddedEvent` stream method. The extension events come in on the isolate event stream.

@danrubel 