### PR TITLE
support calling methods not exposed by this library

### DIFF
--- a/dart/example/vm_service_lib_tester.dart
+++ b/dart/example/vm_service_lib_tester.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:vm_service_lib/vm_service_lib.dart';
+import 'package:vm_service_lib/vm_service_lib_io.dart';
 
 final String host = 'localhost';
 final int port = 7575;
@@ -42,18 +43,9 @@ main(List<String> args) async {
 
   await new Future.delayed(new Duration(milliseconds: 500));
 
-  WebSocket socket = await WebSocket.connect('ws://$host:$port/ws');
+  serviceClient = await vmServiceConnect(host, port, log: new StdoutLog());
 
   print('socket connected');
-
-  StreamController<String> _controller = new StreamController();
-  socket.listen((data) {
-    _controller.add(data);
-  });
-
-  serviceClient = new VmService(_controller.stream, (String message) {
-    socket.add(message);
-  }, log: new StdoutLog());
 
   serviceClient.onSend.listen((str)    => print('--> ${str}'));
   serviceClient.onReceive.listen((str) => print('<-- ${str}'));
@@ -77,7 +69,6 @@ main(List<String> args) async {
   print(await serviceClient.resume(isolateRef.id));
 
   serviceClient.dispose();
-  socket.close();
   process.kill();
 }
 

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -130,13 +130,14 @@ class VmService {
     return controller;
   }
 
-  final DisposeHandler disposeHandler;
+  DisposeHandler _disposeHandler;
 
   VmService(Stream<String> inStream, void writeMessage(String message),
-      {Log log, this.disposeHandler}) {
+      {Log log, DisposeHandler disposeHandler}) {
     _streamSub = inStream.listen(_processMessage);
     _writeMessage = writeMessage;
     _log = log == null ? new _NullLog() : log;
+    _disposeHandler = disposeHandler;
   }
 
   // VMUpdate
@@ -558,7 +559,7 @@ class VmService {
   void dispose() {
     _streamSub.cancel();
     _completers.values.forEach((c) => c.completeError('disposed'));
-    if (disposeHandler != null) disposeHandler();
+    if (_disposeHandler != null) _disposeHandler();
   }
 
   Future<Response> _call(String method, [Map args]) {

--- a/dart/lib/vm_service_lib_io.dart
+++ b/dart/lib/vm_service_lib_io.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/dart/lib/vm_service_lib_io.dart
+++ b/dart/lib/vm_service_lib_io.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'vm_service_lib.dart';
+
+Future<VmService> vmServiceConnect(String host, int port, {Log log}) {
+  return WebSocket.connect('ws://$host:$port/ws').then((WebSocket socket) {
+    StreamController<String> controller = new StreamController();
+    socket.listen((data) => controller.add(data));
+
+    return new VmService(
+        controller.stream, (String message) => socket.add(message),
+        log: log, disposeHandler: () => socket.close());
+  });
+}

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 0.2.4
+version: 0.3.0
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers
@@ -9,8 +9,6 @@ environment:
   sdk: '>=1.13.0 <2.0.0'
 
 dev_dependencies:
-  logging: ^0.11.0
-  markdown: ^0.9.0
+  markdown: ^0.10.0
   path: ^1.0.0
   pub_semver: ^1.0.0
-  test: ^0.12.0

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -78,7 +78,7 @@ final String _implCode = r'''
   void dispose() {
     _streamSub.cancel();
     _completers.values.forEach((c) => c.completeError('disposed'));
-    if (disposeHandler != null) disposeHandler();
+    if (_disposeHandler != null) _disposeHandler();
   }
 
   Future<Response> _call(String method, [Map args]) {
@@ -349,15 +349,16 @@ StreamController<Event> _getEventController(String eventName) {
   return controller;
 }
 
-final DisposeHandler disposeHandler;
+DisposeHandler _disposeHandler;
 
 VmService(Stream<String> inStream, void writeMessage(String message), {
   Log log,
-  this.disposeHandler
+  DisposeHandler disposeHandler
 }) {
   _streamSub = inStream.listen(_processMessage);
   _writeMessage = writeMessage;
   _log = log == null ? new _NullLog() : log;
+  _disposeHandler = disposeHandler;
 }
 
 // VMUpdate

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -38,17 +38,31 @@ final String _headerCode = r'''
 library vm_service_lib;
 
 import 'dart:async';
-import 'dart:convert' show BASE64, JSON, JsonCodec;
+import 'dart:convert' show BASE64, JSON;
 
 ''';
 
 final String _implCode = r'''
 
+  /// Call an arbitrary service protocol method. This allows clients to call
+  /// methds not explicitly exposed by this library.
+  Future<Response> callMethod(String method, {
+    String isolateId,
+    Map args
+  }) {
+    return callServiceExtension(method, isolateId: isolateId, args: args);
+  }
+
   /// Invoke a specific service protocol extension method.
   ///
   /// See https://api.dartlang.org/stable/dart-developer/dart-developer-library.html.
-  Future<Response> callServiceExtension(String method, String isolateId, {Map args}) {
-    if (args == null) {
+  Future<Response> callServiceExtension(String method, {
+    String isolateId,
+    Map args
+  }) {
+    if (args == null && isolateId == null) {
+      return _call(method);
+    } else if (args == null) {
       return _call(method, {'isolateId': isolateId});
     } else {
       args = new Map.from(args);
@@ -64,6 +78,7 @@ final String _implCode = r'''
   void dispose() {
     _streamSub.cancel();
     _completers.values.forEach((c) => c.completeError('disposed'));
+    if (disposeHandler != null) disposeHandler();
   }
 
   Future<Response> _call(String method, [Map args]) {
@@ -114,6 +129,8 @@ final String _implCode = r'''
 ''';
 
 final String _rpcError = r'''
+typedef Future DisposeHandler();
+
 class RPCError {
   static RPCError parse(String callingMethod, dynamic json) {
     return new RPCError(callingMethod, json['code'], json['message'], json['data']);
@@ -332,7 +349,12 @@ StreamController<Event> _getEventController(String eventName) {
   return controller;
 }
 
-VmService(Stream<String> inStream, void writeMessage(String message), {Log log}) {
+final DisposeHandler disposeHandler;
+
+VmService(Stream<String> inStream, void writeMessage(String message), {
+  Log log,
+  this.disposeHandler
+}) {
   _streamSub = inStream.listen(_processMessage);
   _writeMessage = writeMessage;
   _log = log == null ? new _NullLog() : log;


### PR DESCRIPTION
- support calling methods not exposed by this library (`callMethod()`)
- rev the library version
- add a utility methods to help work with `dart:io` (`vmServiceConnect()`)

@danrubel 