### PR TITLE
3.5.0

### DIFF
--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -12,7 +12,7 @@ library vm_service_lib;
 import 'dart:async';
 import 'dart:convert' show BASE64, JSON;
 
-const String vmServiceVersion = '3.4.0';
+const String vmServiceVersion = '3.5.0';
 
 /// @optional
 const String optional = 'optional';
@@ -2572,6 +2572,10 @@ class ScriptRef extends ObjRef {
 /// [lineNumber, (tokenPos, columnNumber)*]
 /// ```
 ///
+/// The `tokenPos` is an arbitrary integer value that is used to represent a
+/// location in the source code. A `tokenPos` value is not meaningful in itself
+/// and code should not rely on the exact values returned.
+///
 /// For example, a `tokenPosTable` with the value...
 ///
 /// ```
@@ -2729,6 +2733,11 @@ class SourceReportRange {
   /// Has this range been compiled by the Dart VM?
   bool compiled;
 
+  /// The error while attempting to compile this range, if this report was
+  /// generated with forceCompile=true.
+  @optional
+  ErrorRef error;
+
   /// Code coverage information for this range.  Provided only when the Coverage
   /// report has been requested and the range has been compiled.
   @optional
@@ -2748,6 +2757,7 @@ class SourceReportRange {
     startPos = json['startPos'];
     endPos = json['endPos'];
     compiled = json['compiled'];
+    error = _createObject(json['error']);
     coverage = _createObject(json['coverage']);
     possibleBreakpoints =
         _createObject(json['possibleBreakpoints']) as List<int>;

--- a/dart/tool/service.md
+++ b/dart/tool/service.md
@@ -1,8 +1,8 @@
-# Dart VM Service Protocol 3.4
+# Dart VM Service Protocol 3.5
 
 > Please post feedback to the [observatory-discuss group][discuss-list]
 
-This document describes of _version 3.4_ of the Dart VM Service Protocol. This
+This document describes of _version 3.5_ of the Dart VM Service Protocol. This
 protocol is used to communicate with a running Dart Virtual Machine.
 
 To use the Service Protocol, start the VM with the *--observe* flag.
@@ -120,7 +120,7 @@ Here is an example response for our [getVersion](#getversion) request above:
   "result": {
     "type": "Version",
     "major": 3,
-    "minor": 0
+    "minor": 5
   }
   "id": "1"
 }
@@ -131,7 +131,7 @@ The JSON-RPC spec provides for _positional_ parameters as well, but they
 are not supported by the Dart VM.
 
 By convention, every response returned by the Service Protocol is a subtype
-of [Response](#response) and provides a _type_ paramters which can be used
+of [Response](#response) and provides a _type_ parameter which can be used
 to distinguish the exact return type. In the example above, the
 [Version](#version) type is returned.
 
@@ -172,8 +172,7 @@ subscribe to the _GC_ stream multiple times from the same client.
 }
 ```
 
-In addition the the [error codes](http://www.jsonrpc.org/specification#error_object)
-specified in the JSON-RPC spec, we use the following application specific error codes:
+In addition to the [error codes](http://www.jsonrpc.org/specification#error_object) specified in the JSON-RPC spec, we use the following application specific error codes:
 
 code | message | meaning
 ---- | ------- | -------
@@ -183,6 +182,7 @@ code | message | meaning
 103 | Stream already subscribed | The client is already subscribed to the specified _streamId_
 104 | Stream not subscribed | The client is not subscribed to the specified _streamId_
 105 | Isolate must be runnable | This operation cannot happen until the isolate is runnable
+106 | Isolate must be paused | This operation is only valid when the isolate is paused
 
 
 
@@ -311,7 +311,7 @@ version number:
   "result": {
     "type": "Version",
     "major": 3,
-    "minor": 0
+    "minor": 5
   }
 ```
 
@@ -2216,6 +2216,10 @@ consists of a line number followed by _(tokenPos, columnNumber)_ pairs:
 
 > [lineNumber, (tokenPos, columnNumber)*]
 
+The _tokenPos_ is an arbitrary integer value that is used to represent
+a location in the source code.  A _tokenPos_ value is not meaningful
+in itself and code should not rely on the exact values returned.
+
 For example, a _tokenPosTable_ with the value...
 
 > [[1, 100, 5, 101, 8],[2, 102, 7]]
@@ -2316,6 +2320,10 @@ class SourceReportRange {
 
   // Has this range been compiled by the Dart VM?
   bool compiled;
+
+  // The error while attempting to compile this range, if this
+  // report was generated with forceCompile=true.
+  @Error error [optional];
 
   // Code coverage information for this range.  Provided only when the
   // Coverage report has been requested and the range has been
@@ -2519,4 +2527,5 @@ version | comments
 3.2 | Isolate objects now include the runnable bit and many debugger related RPCs will return an error if executed on an isolate before it is runnable.
 3.3 | Pause event now indicates if the isolate is paused at an await, yield, or yield* suspension point via the 'atAsyncSuspension' field. Resume command now supports the step parameter 'OverAsyncSuspension'. A Breakpoint added synthetically by an 'OverAsyncSuspension' resume command identifies itself as such via the 'isSyntheticAsyncContinuation' field.
 3.4 | Add the superType and mixin fields to Class. Added new pause event 'None'.
+3.5 | Add the error field to SourceReportRange.  Clarify definition of token position.  Add "Isolate must be paused" error code.
 [discuss-list]: https://groups.google.com/a/dartlang.org/forum/#!forum/observatory-discuss

--- a/java/src/org/dartlang/vm/service/VmService.java
+++ b/java/src/org/dartlang/vm/service/VmService.java
@@ -70,7 +70,7 @@ public class VmService extends VmServiceBase {
   /**
    * The minor version number of the protocol supported by this client.
    */
-  public static final int versionMinor = 4;
+  public static final int versionMinor = 5;
 
   /**
    * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.

--- a/java/src/org/dartlang/vm/service/element/SourceReportRange.java
+++ b/java/src/org/dartlang/vm/service/element/SourceReportRange.java
@@ -51,6 +51,14 @@ public class SourceReportRange extends Element {
   }
 
   /**
+   * The error while attempting to compile this range, if this report was generated with
+   * forceCompile=true.
+   */
+  public ErrorRef getError() {
+    return new ErrorRef((JsonObject) json.get("error"));
+  }
+
+  /**
    * Possible breakpoint information for this range, represented as a sorted list of token
    * positions.  Provided only when the when the PossibleBreakpoint report has been requested and
    * the range has been compiled.

--- a/java/version.txt
+++ b/java/version.txt
@@ -1,1 +1,1 @@
-version=3.4
+version=3.5


### PR DESCRIPTION
rev to `3.5.0`: `'Add the error field to SourceReportRange.  Clarify definition of token position.  Add "Isolate must be paused" error code'`