### PR TITLE
remove log statement

### DIFF
--- a/dart/lib/vm_service_lib_io.dart
+++ b/dart/lib/vm_service_lib_io.dart
@@ -7,8 +7,17 @@ import 'dart:io';
 
 import 'vm_service_lib.dart';
 
-Future<VmService> vmServiceConnect(String host, int port, {Log log}) async {
+Future<VmService> vmServiceConnect(String host, int port, { Log log }) async {
   WebSocket socket = await WebSocket.connect('ws://$host:$port/ws');
+  StreamController<String> controller = new StreamController();
+  socket.listen((data) => controller.add(data));
+  return new VmService(
+      controller.stream, (String message) => socket.add(message),
+      log: log, disposeHandler: () => socket.close());
+}
+
+Future<VmService> vmServiceConnectUri(String wsUri, { Log log }) async {
+  WebSocket socket = await WebSocket.connect(wsUri);
   StreamController<String> controller = new StreamController();
   socket.listen((data) => controller.add(data));
   return new VmService(

--- a/java/src/org/dartlang/vm/service/VmServiceBase.java
+++ b/java/src/org/dartlang/vm/service/VmServiceBase.java
@@ -444,7 +444,6 @@ abstract class VmServiceBase implements VmServiceConst {
         return;
       }
       consumer.onError(new RPCError(error));
-      Logging.getLogger().logError("Error Response: " + error);
       return;
     }
 


### PR DESCRIPTION
@danrubel 

- remove a `logError` statement - the error is already reported back to the calling code (`consumer.onError`)
- some minor updates for the port -> url change