### PR TITLE
rev to 3.6 (unreleased)

### DIFF
--- a/dart/.vscode/launch.json
+++ b/dart/.vscode/launch.json
@@ -6,9 +6,9 @@
       "type": "dart-cli",
       "request": "launch",
       "cwd": "${workspaceRoot}",
-      "sdkPath": "${command.sdkPath}",
       "program": "${workspaceRoot}/tool/generate.dart",
-      "args": []
+      "args": [],
+      "debugSettings": "${command.debugSettings}"
     }
   ]
 }

--- a/dart/example/vm_service_assert.dart
+++ b/dart/example/vm_service_assert.dart
@@ -121,6 +121,7 @@ String assertEventKind(String obj) {
   if (obj == "GC") return obj;
   if (obj == "Inspect") return obj;
   if (obj == "IsolateExit") return obj;
+  if (obj == "IsolateReload") return obj;
   if (obj == "IsolateRunnable") return obj;
   if (obj == "IsolateStart") return obj;
   if (obj == "IsolateUpdate") return obj;
@@ -204,6 +205,7 @@ String assertStepOption(String obj) {
   if (obj == "Out") return obj;
   if (obj == "Over") return obj;
   if (obj == "OverAsyncSuspension") return obj;
+  if (obj == "Rewind") return obj;
   throw "invalid StepOption: $obj";
 }
 
@@ -708,6 +710,13 @@ vms.Obj assertObj(vms.Obj obj) {
   assertNotNull(obj);
   assertString(obj.type);
   assertString(obj.id);
+  return obj;
+}
+
+vms.ReloadReport assertReloadReport(vms.ReloadReport obj) {
+  assertNotNull(obj);
+  assertString(obj.type);
+  assertBool(obj.status);
   return obj;
 }
 

--- a/dart/lib/vm_service_lib_io.dart
+++ b/dart/lib/vm_service_lib_io.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 
 import 'vm_service_lib.dart';
 
-Future<VmService> vmServiceConnect(String host, int port, { Log log }) async {
+Future<VmService> vmServiceConnect(String host, int port, {Log log}) async {
   WebSocket socket = await WebSocket.connect('ws://$host:$port/ws');
   StreamController<String> controller = new StreamController();
   socket.listen((data) => controller.add(data));
@@ -16,7 +16,7 @@ Future<VmService> vmServiceConnect(String host, int port, { Log log }) async {
       log: log, disposeHandler: () => socket.close());
 }
 
-Future<VmService> vmServiceConnectUri(String wsUri, { Log log }) async {
+Future<VmService> vmServiceConnectUri(String wsUri, {Log log}) async {
   WebSocket socket = await WebSocket.connect(wsUri);
   StreamController<String> controller = new StreamController();
   socket.listen((data) => controller.add(data));

--- a/dart/tool/service.md
+++ b/dart/tool/service.md
@@ -37,6 +37,7 @@ The Service Protocol uses [JSON-RPC 2.0][].
 	- [getVersion](#getversion)
 	- [getVM](#getvm)
 	- [pause](#pause)
+  - [reloadSources](#reloadSources)
 	- [removeBreakpoint](#removebreakpoint)
 	- [resume](#resume)
 	- [setExceptionPauseMode](#setexceptionpausemode)
@@ -73,6 +74,7 @@ The Service Protocol uses [JSON-RPC 2.0][].
 	- [Message](#message)
 	- [Null](#null)
 	- [Object](#object)
+  - [ReloadReport](#reloadreport)
 	- [Response](#response)
 	- [Sentinel](#sentinel)
 	- [SentinelKind](#sentinelkind)
@@ -183,7 +185,9 @@ code | message | meaning
 104 | Stream not subscribed | The client is not subscribed to the specified _streamId_
 105 | Isolate must be runnable | This operation cannot happen until the isolate is runnable
 106 | Isolate must be paused | This operation is only valid when the isolate is paused
-
+107 | Cannot resume execution | The isolate could not be resumed
+108 | Isolate is reloading | The isolate is currently processing another reload request
+109 | Isolate cannot be reloaded | The isolate has an unhandled exception and can no longer be reloaded
 
 
 
@@ -651,6 +655,31 @@ When the isolate is paused an event will be sent on the _Debug_ stream.
 
 See [Success](#success).
 
+### reloadSources
+
+
+```
+ReloadReport reloadSources(string isolateId,
+                           bool force [optional],
+                           bool pause [optional],
+                           string rootLibUri [optional],
+                           string packagesUri [optional])
+```
+
+The _reloadSources_ RPC is used to perform a hot reload of an Isolate's sources.
+
+if the _force_ parameter is provided, it indicates that all of the Isolate's
+sources should be reloaded regardless of modification time.
+
+if the _pause_ parameter is provided, the isolate will pause immediately
+after the reload.
+
+if the _rootLibUri_ parameter is provided, it indicates the new uri to the
+Isolate's root library.
+
+if the _packagesUri_ parameter is provided, it indicates the new uri to the
+Isolate's package map (.packages) file.
+
 ### removeBreakpoint
 
 ```
@@ -684,6 +713,7 @@ step | meaning
 Into | Single step, entering function calls
 Over | Single step, skipping over function calls
 Out | Single step until the current function exits
+Rewind | Immediately exit the top frame(s) without executing any code. Isolate will be paused at the call of the last exited function.
 
 See [Success](#success), [StepOption](#StepOption).
 
@@ -768,8 +798,8 @@ The _streamId_ parameter may have the following published values:
 streamId | event types provided
 -------- | -----------
 VM | VMUpdate
-Isolate | IsolateStart, IsolateRunnable, IsolateExit, IsolateUpdate, ServiceExtensionAdded
-Debug | PauseStart, PauseExit, PauseBreakpoint, PauseInterrupted, PauseException, Resume, BreakpointAdded, BreakpointResolved, BreakpointRemoved, Inspect, None
+Isolate | IsolateStart, IsolateRunnable, IsolateExit, IsolateUpdate, IsolateReload, ServiceExtensionAdded
+Debug | PauseStart, PauseExit, PauseBreakpoint, PauseInterrupted, PauseException, PausePostRequest, Resume, BreakpointAdded, BreakpointResolved, BreakpointRemoved, Inspect, None
 GC | GC
 Extension | Extension
 Timeline | TimelineEvents
@@ -1244,6 +1274,12 @@ class Event extends Response {
   //   PauseBreakpoint
   //   PauseInterrupted
   bool atAsyncSuspension [optional];
+
+  // The status (success or failure) related to the event.
+  // This is provided for the event kinds:
+  //   IsolateReloaded
+  //   IsolateSpawn
+  string status [optional];
 }
 ```
 
@@ -1275,6 +1311,9 @@ enum EventKind {
   // via setName.
   IsolateUpdate,
 
+  // Notification that an isolate has been reloaded.
+  IsolateReload,
+
   // Notification that an extension RPC was registered on an isolate.
   ServiceExtensionAdded,
 
@@ -1287,14 +1326,14 @@ enum EventKind {
   // An isolate has paused at a breakpoint or due to stepping.
   PauseBreakpoint,
 
-  // An isolate has paused after a service protocol request.
-  PausePostRequest,
-
   // An isolate has paused due to interruption via pause.
   PauseInterrupted,
 
   // An isolate has paused due to an exception.
   PauseException,
+
+  // An isolate has paused after a service request.
+  PausePostRequest,
 
   // An isolate has started or resumed execution.
   Resume,
@@ -2132,6 +2171,15 @@ class Object extends Response {
 
 An _Object_ is a  persistent object that is owned by some isolate.
 
+### ReloadReport
+
+```
+class ReloadReport extends Response {
+  // Did the reload succeed or fail?
+  bool status;
+}
+```
+
 ### Response
 
 ```
@@ -2386,7 +2434,8 @@ enum StepOption {
   Into,
   Over,
   OverAsyncSuspension,
-  Out
+  Out,
+  Rewind
 }
 ```
 
@@ -2540,6 +2589,6 @@ version | comments
 3.3 | Pause event now indicates if the isolate is paused at an await, yield, or yield* suspension point via the 'atAsyncSuspension' field. Resume command now supports the step parameter 'OverAsyncSuspension'. A Breakpoint added synthetically by an 'OverAsyncSuspension' resume command identifies itself as such via the 'isSyntheticAsyncContinuation' field.
 3.4 | Add the superType and mixin fields to Class. Added new pause event 'None'.
 3.5 | Add the error field to SourceReportRange.  Clarify definition of token position.  Add "Isolate must be paused" error code.
-3.6 (unreleased) | Add 'scopeStartTokenPos', 'scopeEndTokenPos', and 'declarationTokenPos' to BoundVariable.
+3.6 (unreleased) | Add 'scopeStartTokenPos', 'scopeEndTokenPos', and 'declarationTokenPos' to BoundVariable. Add 'PausePostRequest' event kind. Add 'Rewind' StepOption. Add error code 107 (isolate cannot resume). Add 'reloadSources' RPC and related error codes.
 
 [discuss-list]: https://groups.google.com/a/dartlang.org/forum/#!forum/observatory-discuss

--- a/java/src/org/dartlang/vm/service/VmService.java
+++ b/java/src/org/dartlang/vm/service/VmService.java
@@ -277,6 +277,33 @@ public class VmService extends VmServiceBase {
   }
 
   /**
+   * The [reloadSources] RPC is used to perform a hot reload of an Isolate's sources.
+   *
+   * @param force This parameter is optional and may be null.
+   * @param pause This parameter is optional and may be null.
+   * @param rootLibUri This parameter is optional and may be null.
+   * @param packagesUri This parameter is optional and may be null.
+   */
+  public void reloadSources(String isolateId, Boolean force, Boolean pause, String rootLibUri, String packagesUri, ReloadReportConsumer consumer) {
+    JsonObject params = new JsonObject();
+    params.addProperty("isolateId", isolateId);
+    if (force != null) params.addProperty("force", force);
+    if (pause != null) params.addProperty("pause", pause);
+    if (rootLibUri != null) params.addProperty("rootLibUri", rootLibUri);
+    if (packagesUri != null) params.addProperty("packagesUri", packagesUri);
+    request("reloadSources", params, consumer);
+  }
+
+  /**
+   * The [reloadSources] RPC is used to perform a hot reload of an Isolate's sources.
+   */
+  public void reloadSources(String isolateId, ReloadReportConsumer consumer) {
+    JsonObject params = new JsonObject();
+    params.addProperty("isolateId", isolateId);
+    request("reloadSources", params, consumer);
+  }
+
+  /**
    * The [removeBreakpoint] RPC is used to remove a breakpoint by its [id].
    */
   public void removeBreakpoint(String isolateId, String breakpointId, SuccessConsumer consumer) {
@@ -475,6 +502,12 @@ public class VmService extends VmServiceBase {
       }
       if (responseType.equals("TypeArguments")) {
         ((GetObjectConsumer) consumer).received(new TypeArguments(json));
+        return;
+      }
+    }
+    if (consumer instanceof ReloadReportConsumer) {
+      if (responseType.equals("ReloadReport")) {
+        ((ReloadReportConsumer) consumer).received(new ReloadReport(json));
         return;
       }
     }

--- a/java/src/org/dartlang/vm/service/consumer/ReloadReportConsumer.java
+++ b/java/src/org/dartlang/vm/service/consumer/ReloadReportConsumer.java
@@ -11,27 +11,13 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.dartlang.vm.service.element;
+package org.dartlang.vm.service.consumer;
 
 // This is a generated file.
 
-/**
- * A {@link StepOption} indicates which form of stepping is requested in a resume RPC.
- */
-public enum StepOption {
+import org.dartlang.vm.service.element.ReloadReport;
 
-  Into,
+public interface ReloadReportConsumer extends Consumer {
 
-  Out,
-
-  Over,
-
-  OverAsyncSuspension,
-
-  Rewind,
-
-  /**
-   * Represents a value returned by the VM but unknown to this client
-   */
-  Unknown
+  public void received(ReloadReport response);
 }

--- a/java/src/org/dartlang/vm/service/element/Event.java
+++ b/java/src/org/dartlang/vm/service/element/Event.java
@@ -148,6 +148,15 @@ public class Event extends Response {
   }
 
   /**
+   * The status (success or failure) related to the event. This is provided for the event kinds:
+   *  - IsolateReloaded
+   *  - IsolateSpawn
+   */
+  public String getStatus() {
+    return json.get("status").getAsString();
+  }
+
+  /**
    * An array of TimelineEvents
    *
    * This is provided for the TimelineEvents event.

--- a/java/src/org/dartlang/vm/service/element/EventKind.java
+++ b/java/src/org/dartlang/vm/service/element/EventKind.java
@@ -57,6 +57,11 @@ public enum EventKind {
   IsolateExit,
 
   /**
+   * Notification that an isolate has been reloaded.
+   */
+  IsolateReload,
+
+  /**
    * Notification that an isolate is ready to run.
    */
   IsolateRunnable,
@@ -99,7 +104,7 @@ public enum EventKind {
   PauseInterrupted,
 
   /**
-   * An isolate has paused after a service protocol request.
+   * An isolate has paused after a service request.
    */
   PausePostRequest,
 

--- a/java/src/org/dartlang/vm/service/element/ReloadReport.java
+++ b/java/src/org/dartlang/vm/service/element/ReloadReport.java
@@ -15,23 +15,18 @@ package org.dartlang.vm.service.element;
 
 // This is a generated file.
 
-/**
- * A {@link StepOption} indicates which form of stepping is requested in a resume RPC.
- */
-public enum StepOption {
+import com.google.gson.JsonObject;
 
-  Into,
+public class ReloadReport extends Response {
 
-  Out,
-
-  Over,
-
-  OverAsyncSuspension,
-
-  Rewind,
+  public ReloadReport(JsonObject json) {
+    super(json);
+  }
 
   /**
-   * Represents a value returned by the VM but unknown to this client
+   * Did the reload succeed or fail?
    */
-  Unknown
+  public boolean getStatus() {
+    return json.get("status").getAsBoolean();
+  }
 }


### PR DESCRIPTION
Rev to the latest protocol version - capture new info in the spec, like:
- `reloadSources()`
- the `Rewind` stepping option
- the `IsolateReload` and `PostPause` events

@danrubel 