### PR TITLE
fix an issue when deserializing Instances

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.5+1
+- bug fix for deserializing `Instance` objects
+
 ## 0.3.5
 - improve access to the profiling APIs
 

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -2394,8 +2394,10 @@ class Instance extends Obj {
     elements = json['elements'] == null
         ? null
         : new List<dynamic>.from(_createObject(json['elements']));
-    associations = new List<MapAssociation>.from(
-        _createSpecificObject(json['associations'], MapAssociation.parse));
+    associations = json['associations'] == null
+        ? null
+        : new List<MapAssociation>.from(
+            _createSpecificObject(json['associations'], MapAssociation.parse));
     bytes = json['bytes'];
     closureFunction = _createObject(json['closureFunction']);
     closureContext = _createObject(json['closureContext']);

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 0.3.5
+version: 0.3.5+1
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -1015,7 +1015,8 @@ class Type extends Member {
             "extensionData = ExtensionData.parse(json['extensionData']);");
       } else if (name == 'Instance' && field.name == 'associations') {
         // Special case `Instance.associations`.
-        gen.writeln("associations = new List<MapAssociation>.from("
+        gen.writeln("associations = json['associations'] == null "
+            "? null : new List<MapAssociation>.from("
             "_createSpecificObject(json['associations'], MapAssociation.parse));");
       } else if (name == '_CpuProfile' && field.name == 'codes') {
         // Special case `_CpuProfile.codes`.


### PR DESCRIPTION
The `Instance.associations` field is often null - we weren't accounting for this.

@danrubel 