### PR TITLE
upgrades for dart 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: dart
 sudo: false
 dart:
   - dev
-  - stable
 script:
   - (cd dart; ./tool/travis.sh)
   - (cd java; ant -f build.xml)

--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.3.5+2
+## 0.3.7
+- ensure the library works with Dart 2
+- regenerate the library based on the 3.8-dev spec
+- now require a minimum of a 2.0.0-dev Dart SDK
+- update to not use deprecated dart:convert constants
+
+## 0.3.6
 - workaround for an issue with the type of @Library refs for VM objects
 
 ## 0.3.5+1

--- a/dart/example/vm_service_lib_tester.dart
+++ b/dart/example/vm_service_lib_tester.dart
@@ -33,9 +33,9 @@ main(List<String> args) async {
 
   process.exitCode.then((code) => print('vm exited: ${code}'));
   // ignore: strong_mode_down_cast_composite
-  process.stdout.transform(UTF8.decoder).listen(print);
+  process.stdout.transform(utf8.decoder).listen(print);
   // ignore: strong_mode_down_cast_composite
-  process.stderr.transform(UTF8.decoder).listen(print);
+  process.stderr.transform(utf8.decoder).listen(print);
 
   await new Future.delayed(new Duration(milliseconds: 500));
 

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -6,7 +6,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers
 
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=2.0.0-dev.17.0 <2.0.0'
 
 dev_dependencies:
   markdown: '>=0.11.0 < 2.0.0'

--- a/dart/tool/service.md
+++ b/dart/tool/service.md
@@ -1,11 +1,11 @@
 Note: this dev version of the protocol contains not yet released functionality,
 and is subject to change.
 
-# Dart VM Service Protocol 3.6-dev
+# Dart VM Service Protocol 3.8-dev
 
 > Please post feedback to the [observatory-discuss group][discuss-list]
 
-This document describes of _version 3.5_ of the Dart VM Service Protocol. This
+This document describes of _version 3.8-dev_ of the Dart VM Service Protocol. This
 protocol is used to communicate with a running Dart Virtual Machine.
 
 To use the Service Protocol, start the VM with the *--observe* flag.
@@ -44,6 +44,7 @@ The Service Protocol uses [JSON-RPC 2.0][].
 	- [removeBreakpoint](#removebreakpoint)
 	- [resume](#resume)
 	- [setExceptionPauseMode](#setexceptionpausemode)
+	- [setFlag](#setflag)
 	- [setLibraryDebuggable](#setlibrarydebuggable)
 	- [setName](#setname)
 	- [setVMName](#setvmname)
@@ -757,6 +758,24 @@ None | Do not pause isolate on thrown exceptions
 Unhandled | Pause isolate on unhandled exceptions
 All  | Pause isolate on all thrown exceptions
 
+### setFlag
+
+```
+Success setFlag(string name,
+                string value)
+```
+
+The _setFlag_ RPC is used to set a VM flag at runtime. Returns an error if the
+named flag does not exist, the flag may not be set at runtime, or the value is
+of the wrong type for the flag.
+
+The following flags may be set at runtime:
+
+ * pause_isolates_on_start
+ * pause_isolates_on_exit
+ * pause_isolates_on_unhandled_exceptions
+
+See [Success](#success).
 
 ### setLibraryDebuggable
 
@@ -2630,6 +2649,7 @@ version | comments
 3.3 | Pause event now indicates if the isolate is paused at an await, yield, or yield* suspension point via the 'atAsyncSuspension' field. Resume command now supports the step parameter 'OverAsyncSuspension'. A Breakpoint added synthetically by an 'OverAsyncSuspension' resume command identifies itself as such via the 'isSyntheticAsyncContinuation' field.
 3.4 | Add the superType and mixin fields to Class. Added new pause event 'None'.
 3.5 | Add the error field to SourceReportRange.  Clarify definition of token position.  Add "Isolate must be paused" error code.
-3.6 (unreleased) | Add 'scopeStartTokenPos', 'scopeEndTokenPos', and 'declarationTokenPos' to BoundVariable. Add 'PausePostRequest' event kind. Add 'Rewind' StepOption. Add error code 107 (isolate cannot resume). Add 'reloadSources' RPC and related error codes. Add optional parameter 'scope' to 'evaluate' and 'evaluateInFrame'.
+3.6 | Add 'scopeStartTokenPos', 'scopeEndTokenPos', and 'declarationTokenPos' to BoundVariable. Add 'PausePostRequest' event kind. Add 'Rewind' StepOption. Add error code 107 (isolate cannot resume). Add 'reloadSources' RPC and related error codes. Add optional parameter 'scope' to 'evaluate' and 'evaluateInFrame'.
+3.7 | Add 'setFlag'.
 
 [discuss-list]: https://groups.google.com/a/dartlang.org/forum/#!forum/observatory-discuss

--- a/dart/tool/travis.sh
+++ b/dart/tool/travis.sh
@@ -11,14 +11,13 @@ set -e
 pub get
 
 # Ensure the generator works.
-dart -c tool/generate.dart
+dart --preview-dart-2 tool/generate.dart
 
 # Ensure all the code analyzes cleanly.
 dartanalyzer --fatal-warnings \
-  example/sample_exception.dart example/sample_isolates.dart example/sample_main.dart \
-  example/vm_service_assert.dart example/vm_service_lib_tester.dart \
-  lib/vm_service_lib.dart lib/vm_service_lib_io.dart \
-  tool/generate.dart
+  example/ \
+  lib/ \
+  tool/
 
 # Run the VM service protocol smoke tester.
-dart -c example/vm_service_lib_tester.dart
+dart --preview-dart-2 example/vm_service_lib_tester.dart

--- a/java/src/org/dartlang/vm/service/VmService.java
+++ b/java/src/org/dartlang/vm/service/VmService.java
@@ -77,7 +77,7 @@ public class VmService extends VmServiceBase {
   /**
    * The minor version number of the protocol supported by this client.
    */
-  public static final int versionMinor = 6;
+  public static final int versionMinor = 8;
 
   /**
    * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.
@@ -467,6 +467,17 @@ public class VmService extends VmServiceBase {
     params.addProperty("isolateId", isolateId);
     params.addProperty("mode", mode.name());
     request("setExceptionPauseMode", params, consumer);
+  }
+
+  /**
+   * The [setFlag] RPC is used to set a VM flag at runtime. Returns an error if the named flag does
+   * not exist, the flag may not be set at runtime, or the value is of the wrong type for the flag.
+   */
+  public void setFlag(String name, String value, SuccessConsumer consumer) {
+    JsonObject params = new JsonObject();
+    params.addProperty("name", name);
+    params.addProperty("value", value);
+    request("setFlag", params, consumer);
   }
 
   /**

--- a/java/version.properties
+++ b/java/version.properties
@@ -1,1 +1,1 @@
-version=3.6
+version=3.8


### PR DESCRIPTION
- ensure the library works with Dart 2
- regenerate the library based on the 3.8-dev spec
- now require a minimum of a 2.0.0-dev Dart SDK
- update to not use deprecated dart:convert constants
