### PR TITLE
have timestamp return a long

### DIFF
--- a/dart/tool/java/generate_java.dart
+++ b/dart/tool/java/generate_java.dart
@@ -957,12 +957,17 @@ class TypeField extends Member {
         w.addLine('return null;');
       }, javadoc: docs, returnType: 'Object');
     } else {
+      String returnType = type.valueType.ref;
+      if (name == 'timestamp') {
+        returnType = 'long';
+      }
+
       writer.addMethod(accessorName, [], (StatementWriter writer) {
         type.valueType.generateAccessStatements(writer, name,
             canBeSentinel: type.isValueAndSentinel,
             defaultValue: defaultValue,
             optional: optional);
-      }, javadoc: docs, returnType: type.valueType.ref);
+      }, javadoc: docs, returnType: returnType);
     }
   }
 }
@@ -1075,8 +1080,13 @@ class TypeRef {
         writer.addImport('java.util.List');
         writer.addLine('return getListInt("$propertyName");');
       } else {
-        writer.addLine(
-            'return json.get("$propertyName") == null ? -1 : json.get("$propertyName").getAsInt();');
+        if (propertyName == 'timestamp') {
+          writer.addLine(
+              'return json.get("$propertyName") == null ? -1 : json.get("$propertyName").getAsLong();');
+        } else {
+          writer.addLine(
+              'return json.get("$propertyName") == null ? -1 : json.get("$propertyName").getAsInt();');
+        }
       }
     } else if (name == 'double') {
       writer.addLine(

--- a/java/src/org/dartlang/vm/service/VmServiceBase.java
+++ b/java/src/org/dartlang/vm/service/VmServiceBase.java
@@ -117,9 +117,14 @@ abstract class VmServiceBase implements VmServiceConst {
     });
 
     // Establish WebSocket Connection
+    //noinspection TryWithIdenticalCatches
     try {
       webSocket.connect();
     } catch (WebSocketException e) {
+      throw new IOException("Failed to connect: " + url, e);
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // The weberknecht can occasionally throw an array index exception if a connect terminates on initial connect
+      // (de.roderick.weberknecht.WebSocket.connect, WebSocket.java:126).
       throw new IOException("Failed to connect: " + url, e);
     }
     vmService.requestSink = new WebSocketRequestSink(webSocket);

--- a/java/src/org/dartlang/vm/service/element/Event.java
+++ b/java/src/org/dartlang/vm/service/element/Event.java
@@ -212,8 +212,8 @@ public class Event extends Response {
    * pause events, the timestamp is from when the isolate was paused. For other events, the
    * timestamp is from when the event was created.
    */
-  public int getTimestamp() {
-    return json.get("timestamp") == null ? -1 : json.get("timestamp").getAsInt();
+  public long getTimestamp() {
+    return json.get("timestamp") == null ? -1 : json.get("timestamp").getAsLong();
   }
 
   /**


### PR DESCRIPTION
- have timestamp return a long (in the Java impl)
- work around an issue with the weberknecht library