### PR TITLE
update to version 3.14 of the spec; move to a major version numbering scheme

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.14.0
+- regenerate for `v3.14`
+- bump to a major version numbering scheme
+
 ## 0.3.10+2
 - work around an issue de-serializing Instance.closureContext
 

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -13,7 +13,7 @@ import 'dart:async';
 import 'dart:convert' show base64, jsonDecode, jsonEncode, utf8;
 import 'dart:typed_data';
 
-const String vmServiceVersion = '3.12.0';
+const String vmServiceVersion = '3.14.0';
 
 /// @optional
 const String optional = 'optional';
@@ -643,8 +643,8 @@ class VmService {
   /// The `streamListen` RPC subscribes to a stream in the VM. Once subscribed,
   /// the client will begin receiving events from the stream.
   ///
-  /// If the client is not subscribed to the stream, the `103` (Stream already
-  /// subscribed) error code is returned.
+  /// If the client is already subscribed to the stream, the `103` (Stream
+  /// already subscribed) error code is returned.
   ///
   /// The `streamId` parameter may have the following published values:
   ///

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 0.3.10+2
+version: 3.14.0
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers

--- a/dart/tool/service.md
+++ b/dart/tool/service.md
@@ -1,8 +1,8 @@
-# Dart VM Service Protocol 3.12
+# Dart VM Service Protocol 3.14
 
 > Please post feedback to the [observatory-discuss group][discuss-list]
 
-This document describes of _version 3.12_ of the Dart VM Service Protocol. This
+This document describes of _version 3.14_ of the Dart VM Service Protocol. This
 protocol is used to communicate with a running Dart Virtual Machine.
 
 To use the Service Protocol, start the VM with the *--observe* flag.
@@ -31,7 +31,7 @@ The Service Protocol uses [JSON-RPC 2.0][].
   - [evaluateInFrame](#evaluateinframe)
   - [getFlagList](#getflaglist)
   - [getIsolate](#getisolate)
-  - [getScripts](#getisolatescripts)
+  - [getScripts](#getscripts)
   - [getObject](#getobject)
   - [getSourceReport](#getsourcereport)
   - [getStack](#getstack)
@@ -150,7 +150,7 @@ a parameter:
   "jsonrpc": "2.0",
   "method": "streamListen",
   "params": {
-    "streamId": "GC",
+    "streamId": "GC"
   },
   "id": "2"
 }
@@ -842,6 +842,10 @@ The following flags may be set at runtime:
  * pause_isolates_on_start
  * pause_isolates_on_exit
  * pause_isolates_on_unhandled_exceptions
+ * profile_period
+
+Note: `profile_period` can be set to a minimum value of 50. Attempting to set
+`profile_period` to a lower value will result in a value of 50 being set.
 
 See [Success](#success).
 
@@ -901,7 +905,7 @@ Success streamListen(string streamId)
 The _streamListen_ RPC subscribes to a stream in the VM. Once
 subscribed, the client will begin receiving events from the stream.
 
-If the client is not subscribed to the stream, the _103_ (Stream already
+If the client is already subscribed to the stream, the _103_ (Stream already
 subscribed) error code is returned.
 
 The _streamId_ parameter may have the following published values:
@@ -1991,7 +1995,7 @@ enum InstanceKind {
   // Vector instance kinds.
   Float32x4,
   Float64x2,
-  Int32x4
+  Int32x4,
 
   // An instance of the built-in VM TypedData implementations. User-defined
   // TypedDatas will be PlainInstance.
@@ -2734,5 +2738,7 @@ version | comments
 3.10 | Add 'invoke'.
 3.11 | Rename 'invoke' parameter 'receiverId' to 'targetId.
 3.12 | Add 'getScripts' RPC and `ScriptList` object.
+3.13 | Class 'mixin' field now properly set for kernel transformed mixin applications.
+3.14 | Flag 'profile_period' can now be set at runtime, allowing for the profiler sample rate to be changed while the program is running.
 
 [discuss-list]: https://groups.google.com/a/dartlang.org/forum/#!forum/observatory-discuss

--- a/java/src/org/dartlang/vm/service/VmService.java
+++ b/java/src/org/dartlang/vm/service/VmService.java
@@ -77,7 +77,7 @@ public class VmService extends VmServiceBase {
   /**
    * The minor version number of the protocol supported by this client.
    */
-  public static final int versionMinor = 12;
+  public static final int versionMinor = 14;
 
   /**
    * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.

--- a/java/version.properties
+++ b/java/version.properties
@@ -1,1 +1,1 @@
-version=3.12
+version=3.14


### PR DESCRIPTION
- update to version 3.14 of the spec
- move to a major version numbering scheme
