### PR TITLE
Decode strings as UTF8

### DIFF
--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -23,7 +23,7 @@ const String undocumented = 'undocumented';
 
 /// Decode a string in Base64 encoding into the equivalent non-encoded string.
 /// This is useful for handling the results of the Stdout or Stderr events.
-String decodeBase64(String str) => new String.fromCharCodes(base64.decode(str));
+String decodeBase64(String str) => utf8.decode(base64.decode(str));
 
 Object _createObject(dynamic json) {
   if (json == null) return null;

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -400,7 +400,7 @@ const String undocumented = 'undocumented';
 
 /// Decode a string in Base64 encoding into the equivalent non-encoded string.
 /// This is useful for handling the results of the Stdout or Stderr events.
-String decodeBase64(String str) => new String.fromCharCodes(base64.decode(str));
+String decodeBase64(String str) => utf8.decode(base64.decode(str));
 
 Object _createObject(dynamic json) {
   if (json == null) return null;


### PR DESCRIPTION
This fixes https://github.com/flutter/devtools/issues/228.

![screenshot 2019-02-06 at 4 52 02 pm](https://user-images.githubusercontent.com/1078012/52358244-8bdf2f80-2a2f-11e9-9df0-5b4a5b25fdb4.png)

However... I don't know how safe this is. I don't know whether the base64 encoded bytes from the VM are guaranteed to be UTF8. They are in my testing of Flutter in the issue above, but I don't know if it can vary (for example if the running application can set the encoding of these streams, and whether that would change it).

@devoncarew WDYT?