### PR TITLE
Add _Service stream handling in the VmServerConnection/ServiceExtensionRegistry

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.14.3-dev.4
+- Add support for the `_Service` stream in the `VmServerConnection` directly.
+
 ## 3.14.3-dev.3
 - Add support for automatically delegating service extension requests to the
   client which registered them.

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -919,10 +919,14 @@ class VmServerConnection {
         'result': response.toJson(),
         'id': id,
       });
-    } catch (e) {
+    } catch (e, s) {
       var error = e is RPCError
           ? {'code': e.code, 'data': e.data, 'message': e.message}
-          : {'code': -32603, 'message': e.toString()};
+          : {
+              'code': -32603,
+              'data': {'stackTrace': s.toString()},
+              'message': e.toString()
+            };
       _responseSink.add({
         'jsonrpc': '2.0',
         'error': error,

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -657,6 +657,8 @@ class VmServerConnection {
   VmServerConnection(this._requestStream, this._responseSink,
       this._serviceExtensionRegistry, this._serviceImplementation) {
     _requestStream.listen(_delegateRequest, onDone: _doneCompleter.complete);
+    done.then(
+        (_) => _streamSubscriptions.values.forEach((sub) => sub.cancel()));
   }
 
   /// Invoked when the current client has registered some extension, and
@@ -872,8 +874,10 @@ class VmServerConnection {
               'details': "The stream '$id' is already subscribed",
             });
           }
-          _streamSubscriptions[id] =
-              _serviceImplementation.onEvent(id).listen((e) {
+          var stream = id == '_Service'
+              ? _serviceExtensionRegistry.onExtensionEvent
+              : _serviceImplementation.onEvent(id);
+          _streamSubscriptions[id] = stream.listen((e) {
             _responseSink.add({
               'jsonrpc': '2.0',
               'method': 'streamNotify',
@@ -889,9 +893,10 @@ class VmServerConnection {
           var registeredClient = _serviceExtensionRegistry.clientFor(method);
           if (registeredClient != null) {
             // Check for any client which has registered this extension, if we
-            // have one then delgate the request to that client.
-            _responseSink.add(await registeredClient
-                ._forwardServiceExtensionRequest(request));
+            // have one then delegate the request to that client.
+            var result =
+                await registeredClient._forwardServiceExtensionRequest(request);
+            _responseSink.add(result);
             // Bail out early in this case, we are just acting as a proxy and
             // never get a `Response` instance.
             return;

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 3.14.3-dev.3
+version: 3.14.3-dev.4
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   meta: ^1.0.2
+  stream_transform: ^0.0.7
 
 dev_dependencies:
   async: ^2.0.0

--- a/dart/test/server_test.dart
+++ b/dart/test/server_test.dart
@@ -289,13 +289,13 @@ void main() {
             responsesController2.stream,
             emitsThrough(emitsInOrder([
               streamNotifyResponse(
-                  '_Service',
+                  serviceStream,
                   Event()
                     ..kind = EventKind.kServiceRegistered
                     ..method = serviceId
                     ..service = serviceId),
               streamNotifyResponse(
-                  '_Service',
+                  serviceStream,
                   Event()
                     ..kind = EventKind.kServiceUnregistered
                     ..method = serviceId

--- a/dart/test/server_test.dart
+++ b/dart/test/server_test.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 
 import 'package:async/async.dart';
 import 'package:mockito/mockito.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import 'package:vm_service_lib/vm_service_lib.dart';
@@ -305,7 +306,7 @@ void main() {
                   ..method = serviceId
                   ..service = serviceId));
 
-        await requestsController.close();
+        unawaited(requestsController.close());
         // And the unregister event when the original client disconnects.
         expect(
             await responseQueue2.next,


### PR DESCRIPTION
This implements the `_Service` stream in a generic fashion, outside of the actual service implementation which never sees these calls or registrations.