### PR TITLE
Add helper to convert Observatory URI to WS URI

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.15.1
+- Add `getVmWsUriFromObservatoryUri`, a helper function to convert observatory URIs
+  into the required WebSocket URI for connecting to the VM service.
+
 ## 3.15.0
 - support service protocol version 3.15
 - fix an issue decoding null `Script.tokenPosTable` values

--- a/dart/lib/utils.dart
+++ b/dart/lib/utils.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Map the URI (which may already be Observatory web app) to a WebSocket URI
+/// for the VM service.
+///
+/// If the URI is already a VM Service WebSocket URI it will not be modified.
+Uri getVmWsUriFromObservatoryUri(Uri uri) {
+  final isSecure = uri.isScheme('wss') || uri.isScheme('https');
+  final scheme = isSecure ? 'wss' : 'ws';
+
+  final path = uri.path.endsWith('/ws')
+      ? uri.path
+      : (uri.path.endsWith('/') ? '${uri.path}ws' : '${uri.path}/ws');
+
+  return uri.replace(scheme: scheme, path: path);
+}

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 3.15.0
+version: 3.15.1
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers

--- a/dart/test/utils_test.dart
+++ b/dart/test/utils_test.dart
@@ -5,62 +5,31 @@
 import 'package:test/test.dart';
 import 'package:vm_service_lib/utils.dart';
 
-@TestOn('vm')
 void main() {
-  group('getVmWsUriFromObservatoryUri', () {
-    void check(String input, String expected) {
+  test('getVmWsUriFromObservatoryUri maps URIs correctly', () {
+    final testCases = {
+      'http://localhost:123/': 'ws://localhost:123/ws',
+      'https://localhost:123/': 'wss://localhost:123/ws',
+      'ws://localhost:123/': 'ws://localhost:123/ws',
+      'wss://localhost:123/': 'wss://localhost:123/ws',
+      'http://localhost:123/ABCDEF=/': 'ws://localhost:123/ABCDEF=/ws',
+      'https://localhost:123/ABCDEF=/': 'wss://localhost:123/ABCDEF=/ws',
+      'ws://localhost:123/ABCDEF=/': 'ws://localhost:123/ABCDEF=/ws',
+      'wss://localhost:123/ABCDEF=/': 'wss://localhost:123/ABCDEF=/ws',
+      'http://localhost:123': 'ws://localhost:123/ws',
+      'https://localhost:123': 'wss://localhost:123/ws',
+      'ws://localhost:123': 'ws://localhost:123/ws',
+      'wss://localhost:123': 'wss://localhost:123/ws',
+      'http://localhost:123/ABCDEF=': 'ws://localhost:123/ABCDEF=/ws',
+      'https://localhost:123/ABCDEF=': 'wss://localhost:123/ABCDEF=/ws',
+      'ws://localhost:123/ABCDEF=': 'ws://localhost:123/ABCDEF=/ws',
+      'wss://localhost:123/ABCDEF=': 'wss://localhost:123/ABCDEF=/ws',
+    };
+
+    testCases.forEach((String input, String expected) {
       final inputUri = Uri.parse(input);
       final actualUri = getVmWsUriFromObservatoryUri(inputUri);
       expect(actualUri.toString(), equals(expected));
-    }
-
-    test('handles http URIs',
-        () => check('http://localhost:123/', 'ws://localhost:123/ws'));
-    test('handles https URIs',
-        () => check('https://localhost:123/', 'wss://localhost:123/ws'));
-    test('handles ws URIs',
-        () => check('ws://localhost:123/', 'ws://localhost:123/ws'));
-    test('handles wss URIs',
-        () => check('wss://localhost:123/', 'wss://localhost:123/ws'));
-    test(
-        'handles http URIs with tokens',
-        () => check(
-            'http://localhost:123/ABCDEF=/', 'ws://localhost:123/ABCDEF=/ws'));
-    test(
-        'handles https URIs with tokens',
-        () => check('https://localhost:123/ABCDEF=/',
-            'wss://localhost:123/ABCDEF=/ws'));
-    test(
-        'handles ws URIs with tokens',
-        () => check(
-            'ws://localhost:123/ABCDEF=/', 'ws://localhost:123/ABCDEF=/ws'));
-    test(
-        'handles wss URIs with tokens',
-        () => check(
-            'wss://localhost:123/ABCDEF=/', 'wss://localhost:123/ABCDEF=/ws'));
-    test('handles http URIs without trailing slashes',
-        () => check('http://localhost:123', 'ws://localhost:123/ws'));
-    test('handles https URIs without trailing slashes',
-        () => check('https://localhost:123', 'wss://localhost:123/ws'));
-    test('handles ws URIs without trailing slashes',
-        () => check('ws://localhost:123', 'ws://localhost:123/ws'));
-    test('handles wss URIs without trailing slashes',
-        () => check('wss://localhost:123', 'wss://localhost:123/ws'));
-    test(
-        'handles http URIs without trailing slashes with tokens',
-        () => check(
-            'http://localhost:123/ABCDEF=', 'ws://localhost:123/ABCDEF=/ws'));
-    test(
-        'handles https URIs without trailing slashes with tokens',
-        () => check(
-            'https://localhost:123/ABCDEF=', 'wss://localhost:123/ABCDEF=/ws'));
-    test(
-        'handles ws URIs without trailing slashes with tokens',
-        () => check(
-            'ws://localhost:123/ABCDEF=', 'ws://localhost:123/ABCDEF=/ws'));
-    test(
-        'handles wss URIs without trailing slashes with tokens',
-        () => check(
-            'wss://localhost:123/ABCDEF=', 'wss://localhost:123/ABCDEF=/ws'));
+    });
   });
 }

--- a/dart/test/utils_test.dart
+++ b/dart/test/utils_test.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:vm_service_lib/utils.dart';
+
+@TestOn('vm')
+void main() {
+  group('getVmWsUriFromObservatoryUri', () {
+    void check(String input, String expected) {
+      final inputUri = Uri.parse(input);
+      final actualUri = getVmWsUriFromObservatoryUri(inputUri);
+      expect(actualUri.toString(), equals(expected));
+    }
+
+    test('handles http URIs',
+        () => check('http://localhost:123/', 'ws://localhost:123/ws'));
+    test('handles https URIs',
+        () => check('https://localhost:123/', 'wss://localhost:123/ws'));
+    test('handles ws URIs',
+        () => check('ws://localhost:123/', 'ws://localhost:123/ws'));
+    test('handles wss URIs',
+        () => check('wss://localhost:123/', 'wss://localhost:123/ws'));
+    test(
+        'handles http URIs with tokens',
+        () => check(
+            'http://localhost:123/ABCDEF=/', 'ws://localhost:123/ABCDEF=/ws'));
+    test(
+        'handles https URIs with tokens',
+        () => check('https://localhost:123/ABCDEF=/',
+            'wss://localhost:123/ABCDEF=/ws'));
+    test(
+        'handles ws URIs with tokens',
+        () => check(
+            'ws://localhost:123/ABCDEF=/', 'ws://localhost:123/ABCDEF=/ws'));
+    test(
+        'handles wss URIs with tokens',
+        () => check(
+            'wss://localhost:123/ABCDEF=/', 'wss://localhost:123/ABCDEF=/ws'));
+    test('handles http URIs without trailing slashes',
+        () => check('http://localhost:123', 'ws://localhost:123/ws'));
+    test('handles https URIs without trailing slashes',
+        () => check('https://localhost:123', 'wss://localhost:123/ws'));
+    test('handles ws URIs without trailing slashes',
+        () => check('ws://localhost:123', 'ws://localhost:123/ws'));
+    test('handles wss URIs without trailing slashes',
+        () => check('wss://localhost:123', 'wss://localhost:123/ws'));
+    test(
+        'handles http URIs without trailing slashes with tokens',
+        () => check(
+            'http://localhost:123/ABCDEF=', 'ws://localhost:123/ABCDEF=/ws'));
+    test(
+        'handles https URIs without trailing slashes with tokens',
+        () => check(
+            'https://localhost:123/ABCDEF=', 'wss://localhost:123/ABCDEF=/ws'));
+    test(
+        'handles ws URIs without trailing slashes with tokens',
+        () => check(
+            'ws://localhost:123/ABCDEF=', 'ws://localhost:123/ABCDEF=/ws'));
+    test(
+        'handles wss URIs without trailing slashes with tokens',
+        () => check(
+            'wss://localhost:123/ABCDEF=', 'wss://localhost:123/ABCDEF=/ws'));
+  });
+}


### PR DESCRIPTION
This is to make it easier to reuse in devtools+devtools_server (see https://github.com/flutter/devtools/pull/563#discussion_r277432671). I don't know if putting it in a `utils` file is the best place, so let me know if I should move this.