### PR TITLE
rename getVmWsUriFromObservatoryUri to convertToWebSocketUrl

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.15.1+1
+- rename `getVmWsUriFromObservatoryUri` to `convertToWebSocketUrl`
+
 ## 3.15.1
 - Add `getVmWsUriFromObservatoryUri`, a helper function to convert observatory URIs
   into the required WebSocket URI for connecting to the VM service.

--- a/dart/lib/utils.dart
+++ b/dart/lib/utils.dart
@@ -2,17 +2,21 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Map the URI (which may already be Observatory web app) to a WebSocket URI
-/// for the VM service.
+import 'package:meta/meta.dart';
+
+/// Map the URI to a WebSocket URI for the VM service protocol.
 ///
 /// If the URI is already a VM Service WebSocket URI it will not be modified.
-Uri getVmWsUriFromObservatoryUri(Uri uri) {
-  final isSecure = uri.isScheme('wss') || uri.isScheme('https');
+Uri convertToWebSocketUrl({@required Uri serviceProtocolUrl}) {
+  final isSecure = serviceProtocolUrl.isScheme('wss') ||
+      serviceProtocolUrl.isScheme('https');
   final scheme = isSecure ? 'wss' : 'ws';
 
-  final path = uri.path.endsWith('/ws')
-      ? uri.path
-      : (uri.path.endsWith('/') ? '${uri.path}ws' : '${uri.path}/ws');
+  final path = serviceProtocolUrl.path.endsWith('/ws')
+      ? serviceProtocolUrl.path
+      : (serviceProtocolUrl.path.endsWith('/')
+          ? '${serviceProtocolUrl.path}ws'
+          : '${serviceProtocolUrl.path}/ws');
 
-  return uri.replace(scheme: scheme, path: path);
+  return serviceProtocolUrl.replace(scheme: scheme, path: path);
 }

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 3.15.1
+version: 3.15.1+1
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers

--- a/dart/test/utils_test.dart
+++ b/dart/test/utils_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 import 'package:vm_service_lib/utils.dart';
 
 void main() {
-  test('getVmWsUriFromObservatoryUri maps URIs correctly', () {
+  test('convertToWebSocketUrl maps URIs correctly', () {
     final testCases = {
       'http://localhost:123/': 'ws://localhost:123/ws',
       'https://localhost:123/': 'wss://localhost:123/ws',
@@ -28,7 +28,7 @@ void main() {
 
     testCases.forEach((String input, String expected) {
       final inputUri = Uri.parse(input);
-      final actualUri = getVmWsUriFromObservatoryUri(inputUri);
+      final actualUri = convertToWebSocketUrl(serviceProtocolUrl: inputUri);
       expect(actualUri.toString(), equals(expected));
     });
   });


### PR DESCRIPTION
- follow up to https://github.com/dart-lang/vm_service_drivers/pull/232, rename `getVmWsUriFromObservatoryUri` to `convertToWebSocketUrl`

@DanTup 