### PR TITLE
Add helpers for generating result/error

### DIFF
--- a/dart/lib/src/helpers.dart
+++ b/dart/lib/src/helpers.dart
@@ -62,3 +62,27 @@ class TagCounter {
 //  // int chunkCount
 //  // int nodeCount
 //}
+
+/// Wraps a successful result and ensures that it has the required `type` field.
+Map<String, dynamic> resultFor(Map<String, dynamic> result) {
+  if (result == null) {
+    throw ArgumentError.notNull('result');
+  }
+  if (result['type'] == null) {
+    throw ArgumentError.notNull('result["type"]');
+  }
+  return {'result': result};
+}
+
+Map<String, dynamic> errorFor(Map<String, dynamic> error) => {'error': error};
+
+/// The `RpcError` type is used to indicate that an operation did not complete
+/// successfully.
+class RpcError {
+  final String code, message;
+  RpcError(this.code, this.message);
+
+  Map<String, dynamic> toJson() => {'code': code, 'message': message};
+
+  String toString() => '[Error: ${code} ${message}]';
+}

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -15,6 +15,7 @@ import 'dart:typed_data';
 
 import 'src/service_extension_registry.dart';
 
+export 'src/helpers.dart' show resultFor, errorFor, RpcError;
 export 'src/service_extension_registry.dart' show ServiceExtensionRegistry;
 
 const String vmServiceVersion = '3.15.0';

--- a/dart/test/helpers_test.dart
+++ b/dart/test/helpers_test.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:vm_service_lib/vm_service_lib.dart';
+
+void main() {
+  test('resultFor generates the expected JSON', () {
+    final json = jsonEncode(resultFor(Success().toJson()));
+    expect(json, equals('{"result":{"type":"Success"}}'));
+  });
+  test('resultFor throws if given an object without a type field', () {
+    expect(
+      () => resultFor({}),
+      throwsArgumentError,
+    );
+  });
+  test('errorFor generates the expected JSON', () {
+    final json = jsonEncode(errorFor(RpcError("123", 'failed').toJson()));
+    expect(json, equals('{"error":{"code":"123","message":"failed"}}'));
+  });
+}

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -49,6 +49,7 @@ import 'dart:typed_data';
 
 import 'src/service_extension_registry.dart';
 
+export 'src/helpers.dart' show resultFor, errorFor, RpcError;
 export 'src/service_extension_registry.dart' show ServiceExtensionRegistry;
 ''';
 


### PR DESCRIPTION
@devoncarew Not sure if this is exactly what you had in mind (or if you think it's worthwhile). It would be nicer if we could accept "an object that can be JSON encoded" to `resultFor`/`errorFor` (to avoid the caller having to call `.toJson()`), and it also seems like we could merge `errorFor`+`RpcError`, however then it wouldn't me symmetrical with the result one.