### PR TITLE
Fix error object when a service throws

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.15.1+2
+- fix handling of errors in registered service callbacks to return valid
+  JSON-RPC errors and avoid the client getting "Service Disappeared" responses
+
 ## 3.15.1+1
 - rename `getVmWsUriFromObservatoryUri` to `convertToWebSocketUrl`
 - fix an assignment issue in `evaluate`

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -1449,14 +1449,14 @@ class VmService implements VmServiceInterface {
       return {
         'error': {
           'code': -32601, // Method not found
-          'message': 'Method not found \'${method}\''
+          'message': 'Method not found \'$method\''
         }
       };
-    } catch (e, s) {
+    } catch (e, st) {
       return {
         'error': {
           'code': -32000, // SERVER ERROR
-          'message': 'Unexpected Server Error ${e}\n${s}'
+          'message': 'Unexpected Server Error $e\n$st'
         }
       };
     }

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -1453,9 +1453,11 @@ class VmService implements VmServiceInterface {
         }
       };
     } catch (e, s) {
-      return <String, dynamic>{
-        'code': -32000, // SERVER ERROR
-        'message': 'Unexpected Server Error ${e}\n${s}'
+      return {
+        'error': {
+          'code': -32000, // SERVER ERROR
+          'message': 'Unexpected Server Error ${e}\n${s}'
+        }
       };
     }
   }

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 3.15.1+1
+version: 3.15.1+2
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -220,14 +220,14 @@ final String _implCode = r'''
       return {
         'error': {
           'code': -32601, // Method not found
-          'message': 'Method not found \'${method}\''
+          'message': 'Method not found \'$method\''
         }
       };
-    } catch (e, s) {
+    } catch (e, st) {
       return {
         'error': {
           'code': -32000, // SERVER ERROR
-          'message': 'Unexpected Server Error ${e}\n${s}'
+          'message': 'Unexpected Server Error $e\n$st'
         }
       };
     }

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -224,9 +224,11 @@ final String _implCode = r'''
         }
       };
     } catch (e, s) {
-      return <String, dynamic>{
-        'code': -32000, // SERVER ERROR
-        'message': 'Unexpected Server Error ${e}\n${s}'
+      return {
+        'error': {
+          'code': -32000, // SERVER ERROR
+          'message': 'Unexpected Server Error ${e}\n${s}'
+        }
       };
     }
   }


### PR DESCRIPTION
The error object needs to be in an "error" field. The code above does this correctly (Method not found) but this code doesn't. The result is that if an unhandled exception occurred the client would get a ServiceUnregistered event and then "ServiceDisappeared" responses. With this, it gets the expected error and does not unregister the service.

@devoncarew I can't figure out how to put automated tests around this (though I did test it manually with my scripts from https://github.com/DanTup/dart_vm_service_register_service_repro). There are some service registration tests, but they seem to go through `_delegateRequest` whereas this requires `_routeRequest`. Using the mock doesn't help because it doesn't rest the real implementation. Is there an easy/good way to do this?