### PR TITLE
Backwards Compatibility changes for pre 3.18 / 3.19 / 3.20

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.20.0+1
 - handle null isolate ids in `callServiceExtension`
+- add backwards compatibility for `InstanceSet` and `AllocationProfile`
 
 ## 3.20.0
 - rev to 3.20.0; expose public methods added in 3.17 - 3.20 VM Service Protocol versions

--- a/dart/example/vm_service_assert.dart
+++ b/dart/example/vm_service_assert.dart
@@ -640,7 +640,7 @@ vms.InstanceSet assertInstanceSet(vms.InstanceSet obj) {
   assertNotNull(obj);
   assertString(obj.type);
   assertInt(obj.totalCount);
-  assertInstanceRefs(obj.instances);
+  assertObjRefs(obj.instances);
   return obj;
 }
 

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -1215,10 +1215,10 @@ class VmService implements VmServiceInterface {
   Future<AllocationProfile> getAllocationProfile(String isolateId,
       {bool reset, bool gc}) {
     Map m = {'isolateId': isolateId};
-    if (reset != null) {
+    if (reset != null && reset) {
       m['reset'] = reset;
     }
-    if (gc != null) {
+    if (gc != null && gc) {
       m['gc'] = gc;
     }
     return _call('getAllocationProfile', m);

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -370,7 +370,8 @@ abstract class VmServiceInterface {
   /// `limit` is the maximum number of instances to be returned.
   ///
   /// See [InstanceSet].
-  Future<InstanceSet> getInstances(String objectId, int limit);
+  Future<InstanceSet> getInstances(
+      String isolateId, String objectId, int limit);
 
   /// The `getIsolate` RPC is used to lookup an `Isolate` object by its `id`.
   ///
@@ -842,6 +843,7 @@ class VmServerConnection {
           break;
         case 'getInstances':
           response = await _serviceImplementation.getInstances(
+            params['isolateId'],
             params['objectId'],
             params['limit'],
           );
@@ -1226,8 +1228,10 @@ class VmService implements VmServiceInterface {
   Future<FlagList> getFlagList() => _call('getFlagList');
 
   @override
-  Future<InstanceSet> getInstances(String objectId, int limit) {
-    return _call('getInstances', {'objectId': objectId, 'limit': limit});
+  Future<InstanceSet> getInstances(
+      String isolateId, String objectId, int limit) {
+    return _call('getInstances',
+        {'isolateId': isolateId, 'objectId': objectId, 'limit': limit});
   }
 
   @override
@@ -2340,8 +2344,8 @@ class ClassHeapStats extends Response {
     instancesAccumulated = json['instancesAccumulated'];
     instancesCurrent = json['instancesCurrent'];
     classRef = createServiceObject(json['class']);
-    new_ = new List<int>.from(json['new']);
-    old = new List<int>.from(json['old']);
+    new_ = json['new'] == null ? null : new List<int>.from(json['new']);
+    old = json['old'] == null ? null : new List<int>.from(json['old']);
     promotedBytes = json['promotedBytes'];
     promotedInstances = json['promotedInstances'];
   }
@@ -3853,13 +3857,13 @@ class InstanceSet extends Response {
   int totalCount;
 
   /// An array of instances of the requested type.
-  List<InstanceRef> instances;
+  List<ObjRef> instances;
 
   InstanceSet();
 
   InstanceSet._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     totalCount = json['totalCount'];
-    instances = new List<InstanceRef>.from(
+    instances = new List<ObjRef>.from(
         createServiceObject(json['instances'] ?? json['samples']));
   }
 

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -1985,8 +1985,12 @@ class AllocationProfile extends Response {
   AllocationProfile._fromJson(Map<String, dynamic> json)
       : super._fromJson(json) {
     memoryUsage = createServiceObject(json['memoryUsage']);
-    dateLastAccumulatorReset = json['dateLastAccumulatorReset'];
-    dateLastServiceGC = json['dateLastServiceGC'];
+    dateLastAccumulatorReset = json['dateLastAccumulatorReset'] is String
+        ? int.parse(json['dateLastAccumulatorReset'])
+        : json['dateLastAccumulatorReset'];
+    dateLastServiceGC = json['dateLastServiceGC'] is String
+        ? int.parse(json['dateLastServiceGC'])
+        : json['dateLastServiceGC'];
     members =
         new List<ClassHeapStats>.from(createServiceObject(json['members']));
   }
@@ -3855,8 +3859,8 @@ class InstanceSet extends Response {
 
   InstanceSet._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     totalCount = json['totalCount'];
-    instances =
-        new List<InstanceRef>.from(createServiceObject(json['instances']));
+    instances = new List<InstanceRef>.from(
+        createServiceObject(json['instances'] ?? json['samples']));
   }
 
   @override

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -1028,7 +1028,13 @@ class Method extends Member {
       gen.writeln('};');
       args.where((MethodArg a) => a.optional).forEach((MethodArg arg) {
         String valueRef = arg.name;
-        gen.writeln("if (${arg.name} != null) {");
+        // Special case for `getAllocationProfile`. We do not want to add these
+        // params if they are false.
+        if (name == 'getAllocationProfile') {
+          gen.writeln("if (${arg.name} != null && ${arg.name}) {");
+        } else {
+          gen.writeln("if (${arg.name} != null) {");
+        }
         gen.writeln("m['${arg.name}'] = ${valueRef};");
         gen.writeln("}");
       });

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -1392,8 +1392,15 @@ class Type extends Member {
           }
         } else {
           if (fieldType.isListTypeSimple) {
-            gen.writeln("${field.generatableName} = "
-                "new List<${fieldType.listTypeArg}>.from($ref);");
+            // Special case `ClassHeapStats`. Pre 3.18, responses included keys
+            // `new` and `old`. Post 3.18, these will be null.
+            if (name == 'ClassHeapStats') {
+              gen.writeln("${field.generatableName} = $ref == null ? null : "
+                  "new List<${fieldType.listTypeArg}>.from($ref);");
+            } else {
+              gen.writeln("${field.generatableName} = "
+                  "new List<${fieldType.listTypeArg}>.from($ref);");
+            }
           } else {
             // Special case `InstanceSet`. Pre 3.20, instances were sent in a
             // field named 'samples' instead of 'instances'.

--- a/dart/tool/service.md
+++ b/dart/tool/service.md
@@ -643,7 +643,8 @@ See [FlagList](#flaglist).
 ### getInstances
 
 ```
-InstanceSet getInstances(string objectId,
+InstanceSet getInstances(string isolateId,
+                         string objectId,
                          int limit)
 ```
 
@@ -2321,7 +2322,7 @@ class InstanceSet extends Response {
   int totalCount;
 
   // An array of instances of the requested type.
-  @Instance[] instances;
+  @Object[] instances;
 }
 ```
 

--- a/java/src/org/dartlang/vm/service/VmService.java
+++ b/java/src/org/dartlang/vm/service/VmService.java
@@ -273,8 +273,9 @@ public class VmService extends VmServiceBase {
   /**
    * The [getInstances] RPC is used to retrieve a set of instances which are of a specific type.
    */
-  public void getInstances(String objectId, int limit, InstanceSetConsumer consumer) {
+  public void getInstances(String isolateId, String objectId, int limit, InstanceSetConsumer consumer) {
     final JsonObject params = new JsonObject();
+    params.addProperty("isolateId", isolateId);
     params.addProperty("objectId", objectId);
     params.addProperty("limit", limit);
     request("getInstances", params, consumer);

--- a/java/src/org/dartlang/vm/service/element/InstanceSet.java
+++ b/java/src/org/dartlang/vm/service/element/InstanceSet.java
@@ -31,11 +31,11 @@ public class InstanceSet extends Response {
   /**
    * An array of instances of the requested type.
    */
-  public ElementList<InstanceRef> getInstances() {
-    return new ElementList<InstanceRef>(json.get("instances").getAsJsonArray()) {
+  public ElementList<ObjRef> getInstances() {
+    return new ElementList<ObjRef>(json.get("instances").getAsJsonArray()) {
       @Override
-      protected InstanceRef basicGet(JsonArray array, int index) {
-        return new InstanceRef(array.get(index).getAsJsonObject());
+      protected ObjRef basicGet(JsonArray array, int index) {
+        return new ObjRef(array.get(index).getAsJsonObject());
       }
     };
   }


### PR DESCRIPTION
Add a couple special cases to prevent crashes on pre 3.18-3.20.

Also modifies the spec for [`InstanceSet`](https://github.com/dart-lang/sdk/issues/37349) and [`getInstances`](https://github.com/dart-lang/sdk/issues/37351). CL in progress for the upstream changes to https://github.com/dart-lang/sdk/blob/master/runtime/vm/service/service.md.
@devoncarew 