### PR TITLE
remove warnings during code gen

### DIFF
--- a/dart/example/vm_service_assert.dart
+++ b/dart/example/vm_service_assert.dart
@@ -600,6 +600,7 @@ vms.Instance assertInstance(vms.Instance obj) {
   assertString(obj.type);
   assertString(obj.id);
   assertInstanceKind(obj.kind);
+  assertClassRef(obj.classRef);
   return obj;
 }
 
@@ -757,6 +758,7 @@ vms.NullValRef assertNullValRef(vms.NullValRef obj) {
   assertString(obj.id);
   assertInstanceKind(obj.kind);
   assertClassRef(obj.classRef);
+  assertString(obj.valueAsString);
   return obj;
 }
 
@@ -772,6 +774,8 @@ vms.NullVal assertNullVal(vms.NullVal obj) {
   assertString(obj.type);
   assertString(obj.id);
   assertInstanceKind(obj.kind);
+  assertClassRef(obj.classRef);
+  assertString(obj.valueAsString);
   return obj;
 }
 

--- a/java/src/org/dartlang/vm/service/element/Instance.java
+++ b/java/src/org/dartlang/vm/service/element/Instance.java
@@ -93,6 +93,7 @@ public class Instance extends Obj {
   /**
    * Instance references always include their class.
    */
+  @Override
   public ClassRef getClassRef() {
     return new ClassRef((JsonObject) json.get("class"));
   }

--- a/java/src/org/dartlang/vm/service/element/Null.java
+++ b/java/src/org/dartlang/vm/service/element/Null.java
@@ -30,6 +30,7 @@ public class Null extends Instance {
   /**
    * Always 'null'.
    */
+  @Override
   public String getValueAsString() {
     return json.get("valueAsString").getAsString();
   }

--- a/java/src/org/dartlang/vm/service/element/NullRef.java
+++ b/java/src/org/dartlang/vm/service/element/NullRef.java
@@ -30,6 +30,7 @@ public class NullRef extends InstanceRef {
   /**
    * Always 'null'.
    */
+  @Override
   public String getValueAsString() {
     return json.get("valueAsString").getAsString();
   }


### PR DESCRIPTION
remove warnings during code gen:

```
unknown tag: code
unknown tag: code
unknown tag: code
unknown tag: code
Removing duplicate field def: Instance.class.
Removing duplicate field def: NullValRef.valueAsString.
Removing duplicate field def: NullVal.valueAsString.
```

- emit `<code>` tags in the spec as in-line markdown code style
- handle duplicated fields from parent classes by generating `@override` and `@Override` annotations for the subclass methods

With this PR, we now no longer have any warnings at code gen time.

@kenzieschmoll @bkonyi 