### PR TITLE
Handle Instance::null being returned as the value of a non-instance type

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.21.1
+- **breaking**: Fixed issue where an `InstanceRef` of type `null` could be returned
+  instead of null for non-`InstanceRef` properties and return values. As a
+  result, some property and return types have been changed from Obj to their
+  correct types.
+
 ## 3.21.0
 - support service protocol version 3.21
 

--- a/dart/example/vm_service_lib_tester.dart
+++ b/dart/example/vm_service_lib_tester.dart
@@ -76,7 +76,8 @@ void main() {
       expect(originalJson, isNotNull, reason: 'Unrecognized event type! $json');
 
       // ignore: invalid_use_of_visible_for_testing_member
-      var instance = createServiceObject(originalJson);
+      var instance =
+          createServiceObject(originalJson, const ['Event', 'Success']);
       expect(instance, isNotNull,
           reason: 'failed to deserialize object $originalJson!');
 

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -150,45 +150,45 @@ Map<String, Function> _typeFactories = {
 };
 
 Map<String, List<String>> _methodReturnTypes = {
-  'addBreakpoint': ['Breakpoint'],
-  'addBreakpointWithScriptUri': ['Breakpoint'],
-  'addBreakpointAtEntry': ['Breakpoint'],
-  'clearVMTimeline': ['Success'],
-  'invoke': ['InstanceRef', 'ErrorRef', 'Sentinel'],
-  'evaluate': ['InstanceRef', 'ErrorRef', 'Sentinel'],
-  'evaluateInFrame': ['InstanceRef', 'ErrorRef', 'Sentinel'],
-  'getAllocationProfile': ['AllocationProfile'],
-  'getFlagList': ['FlagList'],
-  'getInstances': ['InstanceSet'],
-  'getIsolate': ['Isolate', 'Sentinel'],
-  'getMemoryUsage': ['MemoryUsage', 'Sentinel'],
-  'getScripts': ['ScriptList'],
-  'getObject': ['Obj', 'Sentinel'],
-  'getStack': ['Stack'],
-  'getSourceReport': ['SourceReport'],
-  'getVersion': ['Version'],
-  'getVM': ['VM'],
-  'getVMTimeline': ['Timeline'],
-  'getVMTimelineFlags': ['TimelineFlags'],
-  'getVMTimelineMicros': ['Timestamp'],
-  'pause': ['Success'],
-  'kill': ['Success'],
-  'reloadSources': ['ReloadReport'],
-  'removeBreakpoint': ['Success'],
-  'resume': ['Success'],
-  'setExceptionPauseMode': ['Success'],
-  'setFlag': ['Success'],
-  'setLibraryDebuggable': ['Success'],
-  'setName': ['Success'],
-  'setVMName': ['Success'],
-  'setVMTimelineFlags': ['Success'],
-  'streamCancel': ['Success'],
-  'streamListen': ['Success'],
-  '_collectAllGarbage': ['Success'],
-  '_requestHeapSnapshot': ['Success'],
-  '_clearCpuProfile': ['Success'],
-  '_getCpuProfile': ['_CpuProfile'],
-  '_registerService': ['Success'],
+  'addBreakpoint': const ['Breakpoint'],
+  'addBreakpointWithScriptUri': const ['Breakpoint'],
+  'addBreakpointAtEntry': const ['Breakpoint'],
+  'clearVMTimeline': const ['Success'],
+  'invoke': const ['InstanceRef', 'ErrorRef', 'Sentinel'],
+  'evaluate': const ['InstanceRef', 'ErrorRef', 'Sentinel'],
+  'evaluateInFrame': const ['InstanceRef', 'ErrorRef', 'Sentinel'],
+  'getAllocationProfile': const ['AllocationProfile'],
+  'getFlagList': const ['FlagList'],
+  'getInstances': const ['InstanceSet'],
+  'getIsolate': const ['Isolate', 'Sentinel'],
+  'getMemoryUsage': const ['MemoryUsage', 'Sentinel'],
+  'getScripts': const ['ScriptList'],
+  'getObject': const ['Obj', 'Sentinel'],
+  'getStack': const ['Stack'],
+  'getSourceReport': const ['SourceReport'],
+  'getVersion': const ['Version'],
+  'getVM': const ['VM'],
+  'getVMTimeline': const ['Timeline'],
+  'getVMTimelineFlags': const ['TimelineFlags'],
+  'getVMTimelineMicros': const ['Timestamp'],
+  'pause': const ['Success'],
+  'kill': const ['Success'],
+  'reloadSources': const ['ReloadReport'],
+  'removeBreakpoint': const ['Success'],
+  'resume': const ['Success'],
+  'setExceptionPauseMode': const ['Success'],
+  'setFlag': const ['Success'],
+  'setLibraryDebuggable': const ['Success'],
+  'setName': const ['Success'],
+  'setVMName': const ['Success'],
+  'setVMTimelineFlags': const ['Success'],
+  'streamCancel': const ['Success'],
+  'streamListen': const ['Success'],
+  '_collectAllGarbage': const ['Success'],
+  '_requestHeapSnapshot': const ['Success'],
+  '_clearCpuProfile': const ['Success'],
+  '_getCpuProfile': const ['_CpuProfile'],
+  '_registerService': const ['Success'],
 };
 
 /// A class representation of the Dart VM Service Protocol.
@@ -2054,7 +2054,8 @@ class AllocationProfile extends Response {
 
   AllocationProfile._fromJson(Map<String, dynamic> json)
       : super._fromJson(json) {
-    memoryUsage = createServiceObject(json['memoryUsage'], ['MemoryUsage']);
+    memoryUsage =
+        createServiceObject(json['memoryUsage'], const ['MemoryUsage']);
     dateLastAccumulatorReset = json['dateLastAccumulatorReset'] is String
         ? int.parse(json['dateLastAccumulatorReset'])
         : json['dateLastAccumulatorReset'];
@@ -2062,7 +2063,7 @@ class AllocationProfile extends Response {
         ? int.parse(json['dateLastServiceGC'])
         : json['dateLastServiceGC'];
     members = new List<ClassHeapStats>.from(
-        createServiceObject(json['members'], ['ClassHeapStats']));
+        createServiceObject(json['members'], const ['ClassHeapStats']));
   }
 
   @override
@@ -2102,8 +2103,9 @@ class BoundField {
   BoundField();
 
   BoundField._fromJson(Map<String, dynamic> json) {
-    decl = createServiceObject(json['decl'], ['FieldRef']);
-    value = createServiceObject(json['value'], ['InstanceRef', 'Sentinel']);
+    decl = createServiceObject(json['decl'], const ['FieldRef']);
+    value =
+        createServiceObject(json['value'], const ['InstanceRef', 'Sentinel']);
   }
 
   Map<String, dynamic> toJson() {
@@ -2152,7 +2154,7 @@ class BoundVariable extends Response {
   BoundVariable._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
     value = createServiceObject(
-        json['value'], ['InstanceRef', 'TypeArgumentsRef', 'Sentinel']);
+        json['value'], const ['InstanceRef', 'TypeArgumentsRef', 'Sentinel']);
     declarationTokenPos = json['declarationTokenPos'];
     scopeStartTokenPos = json['scopeStartTokenPos'];
     scopeEndTokenPos = json['scopeEndTokenPos'];
@@ -2211,7 +2213,7 @@ class Breakpoint extends Obj {
     resolved = json['resolved'];
     isSyntheticAsyncContinuation = json['isSyntheticAsyncContinuation'];
     location = createServiceObject(
-        json['location'], ['SourceLocation', 'UnresolvedSourceLocation']);
+        json['location'], const ['SourceLocation', 'UnresolvedSourceLocation']);
   }
 
   @override
@@ -2329,22 +2331,22 @@ class Class extends Obj {
 
   Class._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    error = createServiceObject(json['error'], ['ErrorRef']);
+    error = createServiceObject(json['error'], const ['ErrorRef']);
     isAbstract = json['abstract'];
     isConst = json['const'];
-    library = createServiceObject(json['library'], ['ObjRef']);
-    location = createServiceObject(json['location'], ['SourceLocation']);
-    superClass = createServiceObject(json['super'], ['ClassRef']);
-    superType = createServiceObject(json['superType'], ['InstanceRef']);
+    library = createServiceObject(json['library'], const ['ObjRef']);
+    location = createServiceObject(json['location'], const ['SourceLocation']);
+    superClass = createServiceObject(json['super'], const ['ClassRef']);
+    superType = createServiceObject(json['superType'], const ['InstanceRef']);
     interfaces = new List<InstanceRef>.from(
-        createServiceObject(json['interfaces'], ['InstanceRef']));
-    mixin = createServiceObject(json['mixin'], ['InstanceRef']);
+        createServiceObject(json['interfaces'], const ['InstanceRef']));
+    mixin = createServiceObject(json['mixin'], const ['InstanceRef']);
     fields = new List<FieldRef>.from(
-        createServiceObject(json['fields'], ['FieldRef']));
+        createServiceObject(json['fields'], const ['FieldRef']));
     functions = new List<FuncRef>.from(
-        createServiceObject(json['functions'], ['FuncRef']));
+        createServiceObject(json['functions'], const ['FuncRef']));
     subclasses = new List<ClassRef>.from(
-        createServiceObject(json['subclasses'], ['ClassRef']));
+        createServiceObject(json['subclasses'], const ['ClassRef']));
   }
 
   @override
@@ -2413,7 +2415,7 @@ class ClassHeapStats extends Response {
     bytesCurrent = json['bytesCurrent'];
     instancesAccumulated = json['instancesAccumulated'];
     instancesCurrent = json['instancesCurrent'];
-    classRef = createServiceObject(json['class'], ['ClassRef']);
+    classRef = createServiceObject(json['class'], const ['ClassRef']);
     new_ = json['new'] == null ? null : new List<int>.from(json['new']);
     old = json['old'] == null ? null : new List<int>.from(json['old']);
     promotedBytes = json['promotedBytes'];
@@ -2451,7 +2453,7 @@ class ClassList extends Response {
 
   ClassList._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     classes = new List<ClassRef>.from(
-        createServiceObject(json['classes'], ['ClassRef']));
+        createServiceObject(json['classes'], const ['ClassRef']));
   }
 
   @override
@@ -2592,9 +2594,9 @@ class Context extends Obj {
 
   Context._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     length = json['length'];
-    parent = createServiceObject(json['parent'], ['Context']);
+    parent = createServiceObject(json['parent'], const ['Context']);
     variables = new List<ContextElement>.from(
-        createServiceObject(json['variables'], ['ContextElement']));
+        createServiceObject(json['variables'], const ['ContextElement']));
   }
 
   @override
@@ -2627,7 +2629,8 @@ class ContextElement {
   ContextElement();
 
   ContextElement._fromJson(Map<String, dynamic> json) {
-    value = createServiceObject(json['value'], ['InstanceRef', 'Sentinel']);
+    value =
+        createServiceObject(json['value'], const ['InstanceRef', 'Sentinel']);
   }
 
   Map<String, dynamic> toJson() {
@@ -2705,8 +2708,8 @@ class Error extends Obj {
   Error._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
     message = json['message'];
-    exception = createServiceObject(json['exception'], ['InstanceRef']);
-    stacktrace = createServiceObject(json['stacktrace'], ['InstanceRef']);
+    exception = createServiceObject(json['exception'], const ['InstanceRef']);
+    stacktrace = createServiceObject(json['stacktrace'], const ['InstanceRef']);
   }
 
   @override
@@ -2891,28 +2894,28 @@ class Event extends Response {
 
   Event._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
-    isolate = createServiceObject(json['isolate'], ['IsolateRef']);
-    vm = createServiceObject(json['vm'], ['VMRef']);
+    isolate = createServiceObject(json['isolate'], const ['IsolateRef']);
+    vm = createServiceObject(json['vm'], const ['VMRef']);
     timestamp = json['timestamp'];
-    breakpoint = createServiceObject(json['breakpoint'], ['Breakpoint']);
+    breakpoint = createServiceObject(json['breakpoint'], const ['Breakpoint']);
     pauseBreakpoints = json['pauseBreakpoints'] == null
         ? null
-        : new List<Breakpoint>.from(
-            createServiceObject(json['pauseBreakpoints'], ['Breakpoint']));
-    topFrame = createServiceObject(json['topFrame'], ['Frame']);
-    exception = createServiceObject(json['exception'], ['InstanceRef']);
+        : new List<Breakpoint>.from(createServiceObject(
+            json['pauseBreakpoints'], const ['Breakpoint']));
+    topFrame = createServiceObject(json['topFrame'], const ['Frame']);
+    exception = createServiceObject(json['exception'], const ['InstanceRef']);
     bytes = json['bytes'];
-    inspectee = createServiceObject(json['inspectee'], ['InstanceRef']);
+    inspectee = createServiceObject(json['inspectee'], const ['InstanceRef']);
     extensionRPC = json['extensionRPC'];
     extensionKind = json['extensionKind'];
     extensionData = ExtensionData.parse(json['extensionData']);
     timelineEvents = json['timelineEvents'] == null
         ? null
-        : new List<TimelineEvent>.from(
-            createServiceObject(json['timelineEvents'], ['TimelineEvent']));
+        : new List<TimelineEvent>.from(createServiceObject(
+            json['timelineEvents'], const ['TimelineEvent']));
     atAsyncSuspension = json['atAsyncSuspension'];
     status = json['status'];
-    logRecord = createServiceObject(json['logRecord'], ['LogRecord']);
+    logRecord = createServiceObject(json['logRecord'], const ['LogRecord']);
     service = json['service'];
     method = json['method'];
     alias = json['alias'];
@@ -2983,8 +2986,9 @@ class FieldRef extends ObjRef {
 
   FieldRef._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    owner = createServiceObject(json['owner'], ['ObjRef']);
-    declaredType = createServiceObject(json['declaredType'], ['InstanceRef']);
+    owner = createServiceObject(json['owner'], const ['ObjRef']);
+    declaredType =
+        createServiceObject(json['declaredType'], const ['InstanceRef']);
     isConst = json['const'];
     isFinal = json['final'];
     isStatic = json['static'];
@@ -3050,13 +3054,15 @@ class Field extends Obj {
 
   Field._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    owner = createServiceObject(json['owner'], ['ObjRef']);
-    declaredType = createServiceObject(json['declaredType'], ['InstanceRef']);
+    owner = createServiceObject(json['owner'], const ['ObjRef']);
+    declaredType =
+        createServiceObject(json['declaredType'], const ['InstanceRef']);
     isConst = json['const'];
     isFinal = json['final'];
     isStatic = json['static'];
-    staticValue = createServiceObject(json['staticValue'], ['InstanceRef']);
-    location = createServiceObject(json['location'], ['SourceLocation']);
+    staticValue =
+        createServiceObject(json['staticValue'], const ['InstanceRef']);
+    location = createServiceObject(json['location'], const ['SourceLocation']);
   }
 
   @override
@@ -3138,7 +3144,8 @@ class FlagList extends Response {
   FlagList();
 
   FlagList._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    flags = new List<Flag>.from(createServiceObject(json['flags'], ['Flag']));
+    flags =
+        new List<Flag>.from(createServiceObject(json['flags'], const ['Flag']));
   }
 
   @override
@@ -3180,13 +3187,13 @@ class Frame extends Response {
 
   Frame._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     index = json['index'];
-    function = createServiceObject(json['function'], ['FuncRef']);
-    code = createServiceObject(json['code'], ['CodeRef']);
-    location = createServiceObject(json['location'], ['SourceLocation']);
+    function = createServiceObject(json['function'], const ['FuncRef']);
+    code = createServiceObject(json['code'], const ['CodeRef']);
+    location = createServiceObject(json['location'], const ['SourceLocation']);
     vars = json['vars'] == null
         ? null
         : new List<BoundVariable>.from(
-            createServiceObject(json['vars'], ['BoundVariable']));
+            createServiceObject(json['vars'], const ['BoundVariable']));
     kind = json['kind'];
   }
 
@@ -3232,7 +3239,7 @@ class FuncRef extends ObjRef {
   FuncRef._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
     owner = createServiceObject(
-        json['owner'], ['LibraryRef', 'ClassRef', 'FuncRef']);
+        json['owner'], const ['LibraryRef', 'ClassRef', 'FuncRef']);
     isStatic = json['static'];
     isConst = json['const'];
   }
@@ -3285,9 +3292,9 @@ class Func extends Obj {
   Func._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
     owner = createServiceObject(
-        json['owner'], ['LibraryRef', 'ClassRef', 'FuncRef']);
-    location = createServiceObject(json['location'], ['SourceLocation']);
-    code = createServiceObject(json['code'], ['CodeRef']);
+        json['owner'], const ['LibraryRef', 'ClassRef', 'FuncRef']);
+    location = createServiceObject(json['location'], const ['SourceLocation']);
+    code = createServiceObject(json['code'], const ['CodeRef']);
   }
 
   @override
@@ -3402,15 +3409,15 @@ class InstanceRef extends ObjRef {
 
   InstanceRef._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
-    classRef = createServiceObject(json['class'], ['ClassRef']);
+    classRef = createServiceObject(json['class'], const ['ClassRef']);
     valueAsString = json['valueAsString'];
     valueAsStringIsTruncated = json['valueAsStringIsTruncated'] ?? false;
     length = json['length'];
     name = json['name'];
-    typeClass = createServiceObject(json['typeClass'], ['ClassRef']);
+    typeClass = createServiceObject(json['typeClass'], const ['ClassRef']);
     parameterizedClass =
-        createServiceObject(json['parameterizedClass'], ['ClassRef']);
-    pattern = createServiceObject(json['pattern'], ['InstanceRef']);
+        createServiceObject(json['parameterizedClass'], const ['ClassRef']);
+    pattern = createServiceObject(json['pattern'], const ['InstanceRef']);
   }
 
   @override
@@ -3699,44 +3706,47 @@ class Instance extends Obj {
 
   Instance._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
-    classRef = createServiceObject(json['class'], ['ClassRef']);
+    classRef = createServiceObject(json['class'], const ['ClassRef']);
     valueAsString = json['valueAsString'];
     valueAsStringIsTruncated = json['valueAsStringIsTruncated'] ?? false;
     length = json['length'];
     offset = json['offset'];
     count = json['count'];
     name = json['name'];
-    typeClass = createServiceObject(json['typeClass'], ['ClassRef']);
+    typeClass = createServiceObject(json['typeClass'], const ['ClassRef']);
     parameterizedClass =
-        createServiceObject(json['parameterizedClass'], ['ClassRef']);
+        createServiceObject(json['parameterizedClass'], const ['ClassRef']);
     fields = json['fields'] == null
         ? null
         : new List<BoundField>.from(
-            createServiceObject(json['fields'], ['BoundField']));
+            createServiceObject(json['fields'], const ['BoundField']));
     elements = json['elements'] == null
         ? null
         : new List<dynamic>.from(
-            createServiceObject(json['elements'], ['dynamic']));
+            createServiceObject(json['elements'], const ['dynamic']));
     associations = json['associations'] == null
         ? null
         : new List<MapAssociation>.from(
             _createSpecificObject(json['associations'], MapAssociation.parse));
     bytes = json['bytes'];
-    closureFunction = createServiceObject(json['closureFunction'], ['FuncRef']);
+    closureFunction =
+        createServiceObject(json['closureFunction'], const ['FuncRef']);
     closureContext =
-        createServiceObject(json['closureContext'], ['ContextRef']);
+        createServiceObject(json['closureContext'], const ['ContextRef']);
     mirrorReferent =
-        createServiceObject(json['mirrorReferent'], ['InstanceRef']);
+        createServiceObject(json['mirrorReferent'], const ['InstanceRef']);
     pattern = json['pattern'];
     isCaseSensitive = json['isCaseSensitive'];
     isMultiLine = json['isMultiLine'];
-    propertyKey = createServiceObject(json['propertyKey'], ['InstanceRef']);
-    propertyValue = createServiceObject(json['propertyValue'], ['InstanceRef']);
+    propertyKey =
+        createServiceObject(json['propertyKey'], const ['InstanceRef']);
+    propertyValue =
+        createServiceObject(json['propertyValue'], const ['InstanceRef']);
     typeArguments =
-        createServiceObject(json['typeArguments'], ['TypeArgumentsRef']);
+        createServiceObject(json['typeArguments'], const ['TypeArgumentsRef']);
     parameterIndex = json['parameterIndex'];
-    targetType = createServiceObject(json['targetType'], ['InstanceRef']);
-    bound = createServiceObject(json['bound'], ['InstanceRef']);
+    targetType = createServiceObject(json['targetType'], const ['InstanceRef']);
+    bound = createServiceObject(json['bound'], const ['InstanceRef']);
   }
 
   @override
@@ -3895,13 +3905,13 @@ class Isolate extends Response {
     runnable = json['runnable'];
     livePorts = json['livePorts'];
     pauseOnExit = json['pauseOnExit'];
-    pauseEvent = createServiceObject(json['pauseEvent'], ['Event']);
-    rootLib = createServiceObject(json['rootLib'], ['LibraryRef']);
+    pauseEvent = createServiceObject(json['pauseEvent'], const ['Event']);
+    rootLib = createServiceObject(json['rootLib'], const ['LibraryRef']);
     libraries = new List<LibraryRef>.from(
-        createServiceObject(json['libraries'], ['LibraryRef']));
+        createServiceObject(json['libraries'], const ['LibraryRef']));
     breakpoints = new List<Breakpoint>.from(
-        createServiceObject(json['breakpoints'], ['Breakpoint']));
-    error = createServiceObject(json['error'], ['Error']);
+        createServiceObject(json['breakpoints'], const ['Breakpoint']));
+    error = createServiceObject(json['error'], const ['Error']);
     exceptionPauseMode = json['exceptionPauseMode'];
     extensionRPCs = json['extensionRPCs'] == null
         ? null
@@ -3954,8 +3964,8 @@ class InstanceSet extends Response {
 
   InstanceSet._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     totalCount = json['totalCount'];
-    instances = new List<ObjRef>.from(
-        createServiceObject(json['instances'] ?? json['samples'], ['ObjRef']));
+    instances = new List<ObjRef>.from(createServiceObject(
+        json['instances'] ?? json['samples'], const ['ObjRef']));
   }
 
   @override
@@ -4050,13 +4060,13 @@ class Library extends Obj {
     dependencies = new List<LibraryDependency>.from(
         _createSpecificObject(json['dependencies'], LibraryDependency.parse));
     scripts = new List<ScriptRef>.from(
-        createServiceObject(json['scripts'], ['ScriptRef']));
+        createServiceObject(json['scripts'], const ['ScriptRef']));
     variables = new List<FieldRef>.from(
-        createServiceObject(json['variables'], ['FieldRef']));
+        createServiceObject(json['variables'], const ['FieldRef']));
     functions = new List<FuncRef>.from(
-        createServiceObject(json['functions'], ['FuncRef']));
+        createServiceObject(json['functions'], const ['FuncRef']));
     classes = new List<ClassRef>.from(
-        createServiceObject(json['classes'], ['ClassRef']));
+        createServiceObject(json['classes'], const ['ClassRef']));
   }
 
   @override
@@ -4106,7 +4116,7 @@ class LibraryDependency {
     isImport = json['isImport'];
     isDeferred = json['isDeferred'];
     prefix = json['prefix'];
-    target = createServiceObject(json['target'], ['LibraryRef']);
+    target = createServiceObject(json['target'], const ['LibraryRef']);
   }
 
   Map<String, dynamic> toJson() {
@@ -4159,14 +4169,14 @@ class LogRecord extends Response {
   LogRecord();
 
   LogRecord._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    message = createServiceObject(json['message'], ['InstanceRef']);
+    message = createServiceObject(json['message'], const ['InstanceRef']);
     time = json['time'];
     level = json['level'];
     sequenceNumber = json['sequenceNumber'];
-    loggerName = createServiceObject(json['loggerName'], ['InstanceRef']);
-    zone = createServiceObject(json['zone'], ['InstanceRef']);
-    error = createServiceObject(json['error'], ['InstanceRef']);
-    stackTrace = createServiceObject(json['stackTrace'], ['InstanceRef']);
+    loggerName = createServiceObject(json['loggerName'], const ['InstanceRef']);
+    zone = createServiceObject(json['zone'], const ['InstanceRef']);
+    error = createServiceObject(json['error'], const ['InstanceRef']);
+    stackTrace = createServiceObject(json['stackTrace'], const ['InstanceRef']);
   }
 
   @override
@@ -4202,8 +4212,9 @@ class MapAssociation {
   MapAssociation();
 
   MapAssociation._fromJson(Map<String, dynamic> json) {
-    key = createServiceObject(json['key'], ['InstanceRef', 'Sentinel']);
-    value = createServiceObject(json['value'], ['InstanceRef', 'Sentinel']);
+    key = createServiceObject(json['key'], const ['InstanceRef', 'Sentinel']);
+    value =
+        createServiceObject(json['value'], const ['InstanceRef', 'Sentinel']);
   }
 
   Map<String, dynamic> toJson() {
@@ -4300,8 +4311,8 @@ class Message extends Response {
     name = json['name'];
     messageObjectId = json['messageObjectId'];
     size = json['size'];
-    handler = createServiceObject(json['handler'], ['FuncRef']);
-    location = createServiceObject(json['location'], ['SourceLocation']);
+    handler = createServiceObject(json['handler'], const ['FuncRef']);
+    location = createServiceObject(json['location'], const ['SourceLocation']);
   }
 
   @override
@@ -4475,7 +4486,7 @@ class Obj extends Response {
   Obj._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     id = json['id'];
     fixedId = json['fixedId'];
-    classRef = createServiceObject(json['class'], ['ClassRef']);
+    classRef = createServiceObject(json['class'], const ['ClassRef']);
     size = json['size'];
   }
 
@@ -4680,7 +4691,7 @@ class Script extends Obj {
 
   Script._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     uri = json['uri'];
-    library = createServiceObject(json['library'], ['LibraryRef']);
+    library = createServiceObject(json['library'], const ['LibraryRef']);
     lineOffset = json['lineOffset'];
     columnOffset = json['columnOffset'];
     source = json['source'];
@@ -4724,7 +4735,7 @@ class ScriptList extends Response {
 
   ScriptList._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     scripts = new List<ScriptRef>.from(
-        createServiceObject(json['scripts'], ['ScriptRef']));
+        createServiceObject(json['scripts'], const ['ScriptRef']));
   }
 
   @override
@@ -4759,7 +4770,7 @@ class SourceLocation extends Response {
   SourceLocation();
 
   SourceLocation._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    script = createServiceObject(json['script'], ['ScriptRef']);
+    script = createServiceObject(json['script'], const ['ScriptRef']);
     tokenPos = json['tokenPos'];
     endTokenPos = json['endTokenPos'];
   }
@@ -4805,7 +4816,7 @@ class SourceReport extends Response {
     ranges = new List<SourceReportRange>.from(
         _createSpecificObject(json['ranges'], SourceReportRange.parse));
     scripts = new List<ScriptRef>.from(
-        createServiceObject(json['scripts'], ['ScriptRef']));
+        createServiceObject(json['scripts'], const ['ScriptRef']));
   }
 
   @override
@@ -4907,7 +4918,7 @@ class SourceReportRange {
     startPos = json['startPos'];
     endPos = json['endPos'];
     compiled = json['compiled'];
-    error = createServiceObject(json['error'], ['ErrorRef']);
+    error = createServiceObject(json['error'], const ['ErrorRef']);
     coverage =
         _createSpecificObject(json['coverage'], SourceReportCoverage.parse);
     possibleBreakpoints = json['possibleBreakpoints'] == null
@@ -4952,18 +4963,18 @@ class Stack extends Response {
   Stack();
 
   Stack._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    frames =
-        new List<Frame>.from(createServiceObject(json['frames'], ['Frame']));
+    frames = new List<Frame>.from(
+        createServiceObject(json['frames'], const ['Frame']));
     asyncCausalFrames = json['asyncCausalFrames'] == null
         ? null
         : new List<Frame>.from(
-            createServiceObject(json['asyncCausalFrames'], ['Frame']));
+            createServiceObject(json['asyncCausalFrames'], const ['Frame']));
     awaiterFrames = json['awaiterFrames'] == null
         ? null
         : new List<Frame>.from(
-            createServiceObject(json['awaiterFrames'], ['Frame']));
+            createServiceObject(json['awaiterFrames'], const ['Frame']));
     messages = new List<Message>.from(
-        createServiceObject(json['messages'], ['Message']));
+        createServiceObject(json['messages'], const ['Message']));
   }
 
   @override
@@ -5022,7 +5033,7 @@ class Timeline extends Response {
 
   Timeline._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     traceEvents = new List<TimelineEvent>.from(
-        createServiceObject(json['traceEvents'], ['TimelineEvent']));
+        createServiceObject(json['traceEvents'], const ['TimelineEvent']));
     timeOriginMicros = json['timeOriginMicros'];
     timeExtentMicros = json['timeExtentMicros'];
   }
@@ -5181,7 +5192,7 @@ class TypeArguments extends Obj {
   TypeArguments._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
     types = new List<InstanceRef>.from(
-        createServiceObject(json['types'], ['InstanceRef']));
+        createServiceObject(json['types'], const ['InstanceRef']));
   }
 
   @override
@@ -5245,7 +5256,7 @@ class UnresolvedSourceLocation extends Response {
 
   UnresolvedSourceLocation._fromJson(Map<String, dynamic> json)
       : super._fromJson(json) {
-    script = createServiceObject(json['script'], ['ScriptRef']);
+    script = createServiceObject(json['script'], const ['ScriptRef']);
     scriptUri = json['scriptUri'];
     tokenPos = json['tokenPos'];
     line = json['line'];
@@ -5370,7 +5381,7 @@ class VM extends Response {
     pid = json['pid'];
     startTime = json['startTime'];
     isolates = new List<IsolateRef>.from(
-        createServiceObject(json['isolates'], ['IsolateRef']));
+        createServiceObject(json['isolates'], const ['IsolateRef']));
   }
 
   @override
@@ -5483,7 +5494,7 @@ class CodeRegion {
     kind = json['kind'];
     inclusiveTicks = json['inclusiveTicks'];
     exclusiveTicks = json['exclusiveTicks'];
-    code = createServiceObject(json['code'], ['CodeRef']);
+    code = createServiceObject(json['code'], const ['CodeRef']);
   }
 
   Map<String, dynamic> toJson() {
@@ -5522,7 +5533,7 @@ class ProfileFunction {
     kind = json['kind'];
     inclusiveTicks = json['inclusiveTicks'];
     exclusiveTicks = json['exclusiveTicks'];
-    function = createServiceObject(json['function'], ['FuncRef']);
+    function = createServiceObject(json['function'], const ['FuncRef']);
     codes = new List<int>.from(json['codes']);
   }
 

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -33,7 +33,7 @@ String decodeBase64(String str) => utf8.decode(base64.decode(str));
 bool _isNullInstance(Map json) =>
     ((json['type'] == '@Instance') && (json['kind'] == 'Null'));
 
-Object createServiceObject(dynamic json, [List<String> expectedTypes]) {
+Object createServiceObject(dynamic json, List<String> expectedTypes) {
   if (json == null) return null;
 
   if (json is List) {
@@ -1598,7 +1598,8 @@ class VmService implements VmServiceInterface {
       String streamId = map['params']['streamId'];
       Map event = map['params']['event'];
       event['_data'] = data;
-      _getEventController(streamId).add(createServiceObject(event));
+      _getEventController(streamId)
+          .add(createServiceObject(event, const ['Event']));
     }
   }
 
@@ -1660,7 +1661,8 @@ class VmService implements VmServiceInterface {
     final Map params = json['params'];
     if (method == 'streamNotify') {
       String streamId = params['streamId'];
-      _getEventController(streamId).add(createServiceObject(params['event']));
+      _getEventController(streamId)
+          .add(createServiceObject(params['event'], const ['Event']));
     } else {
       await _routeRequest(method, params);
     }

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -29,13 +29,20 @@ const String undocumented = 'undocumented';
 /// This is useful for handling the results of the Stdout or Stderr events.
 String decodeBase64(String str) => utf8.decode(base64.decode(str));
 
-Object createServiceObject(dynamic json) {
+// Returns true if a response is the Dart `null` instance.
+bool _isNullInstance(Map json) =>
+    ((json['type'] == '@Instance') && (json['kind'] == 'Null'));
+
+Object createServiceObject(dynamic json, [String expectedType]) {
   if (json == null) return null;
 
   if (json is List) {
-    return json.map((e) => createServiceObject(e)).toList();
+    return json.map((e) => createServiceObject(e, expectedType)).toList();
   } else if (json is Map) {
     String type = json['type'];
+    if (_isNullInstance(json) && (expectedType != type)) {
+      return null;
+    }
     if (_typeFactories[type] == null) {
       return null;
     } else {
@@ -140,6 +147,48 @@ Map<String, Function> _typeFactories = {
   'CodeRegion': CodeRegion.parse,
   'ProfileFunction': ProfileFunction.parse,
   'HeapSpace': HeapSpace.parse,
+};
+
+Map<String, String> _methodReturnTypes = {
+  'addBreakpoint': 'Breakpoint',
+  'addBreakpointWithScriptUri': 'Breakpoint',
+  'addBreakpointAtEntry': 'Breakpoint',
+  'clearVMTimeline': 'Success',
+  'invoke': 'dynamic',
+  'evaluate': 'dynamic',
+  'evaluateInFrame': 'dynamic',
+  'getAllocationProfile': 'AllocationProfile',
+  'getFlagList': 'FlagList',
+  'getInstances': 'InstanceSet',
+  'getIsolate': 'dynamic',
+  'getMemoryUsage': 'dynamic',
+  'getScripts': 'ScriptList',
+  'getObject': 'dynamic',
+  'getStack': 'Stack',
+  'getSourceReport': 'SourceReport',
+  'getVersion': 'Version',
+  'getVM': 'VM',
+  'getVMTimeline': 'Timeline',
+  'getVMTimelineFlags': 'TimelineFlags',
+  'getVMTimelineMicros': 'Timestamp',
+  'pause': 'Success',
+  'kill': 'Success',
+  'reloadSources': 'ReloadReport',
+  'removeBreakpoint': 'Success',
+  'resume': 'Success',
+  'setExceptionPauseMode': 'Success',
+  'setFlag': 'Success',
+  'setLibraryDebuggable': 'Success',
+  'setName': 'Success',
+  'setVMName': 'Success',
+  'setVMTimelineFlags': 'Success',
+  'streamCancel': 'Success',
+  'streamListen': 'Success',
+  '_collectAllGarbage': 'Success',
+  '_requestHeapSnapshot': 'Success',
+  '_clearCpuProfile': 'Success',
+  '_getCpuProfile': 'CpuProfile',
+  '_registerService': 'Success',
 };
 
 /// A class representation of the Dart VM Service Protocol.
@@ -1581,7 +1630,7 @@ class VmService implements VmServiceInterface {
   void _processResponse(Map<String, dynamic> json) {
     Completer completer = _completers.remove(json['id']);
     String methodName = _methodCalls.remove(json['id']);
-
+    String returnType = _methodReturnTypes[methodName];
     if (completer == null) {
       _log.severe('unmatched request response: ${jsonEncode(json)}');
     } else if (json['error'] != null) {
@@ -1592,7 +1641,7 @@ class VmService implements VmServiceInterface {
       if (_typeFactories[type] == null) {
         completer.complete(Response.parse(result));
       } else {
-        completer.complete(createServiceObject(result));
+        completer.complete(createServiceObject(result, returnType));
       }
     }
   }
@@ -2003,15 +2052,15 @@ class AllocationProfile extends Response {
 
   AllocationProfile._fromJson(Map<String, dynamic> json)
       : super._fromJson(json) {
-    memoryUsage = createServiceObject(json['memoryUsage']);
+    memoryUsage = createServiceObject(json['memoryUsage'], 'MemoryUsage');
     dateLastAccumulatorReset = json['dateLastAccumulatorReset'] is String
         ? int.parse(json['dateLastAccumulatorReset'])
         : json['dateLastAccumulatorReset'];
     dateLastServiceGC = json['dateLastServiceGC'] is String
         ? int.parse(json['dateLastServiceGC'])
         : json['dateLastServiceGC'];
-    members =
-        new List<ClassHeapStats>.from(createServiceObject(json['members']));
+    members = new List<ClassHeapStats>.from(
+        createServiceObject(json['members'], 'ClassHeapStats'));
   }
 
   @override
@@ -2051,8 +2100,8 @@ class BoundField {
   BoundField();
 
   BoundField._fromJson(Map<String, dynamic> json) {
-    decl = createServiceObject(json['decl']);
-    value = createServiceObject(json['value']);
+    decl = createServiceObject(json['decl'], 'FieldRef');
+    value = createServiceObject(json['value'], 'dynamic');
   }
 
   Map<String, dynamic> toJson() {
@@ -2100,7 +2149,7 @@ class BoundVariable extends Response {
 
   BoundVariable._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    value = createServiceObject(json['value']);
+    value = createServiceObject(json['value'], 'dynamic');
     declarationTokenPos = json['declarationTokenPos'];
     scopeStartTokenPos = json['scopeStartTokenPos'];
     scopeEndTokenPos = json['scopeEndTokenPos'];
@@ -2158,7 +2207,7 @@ class Breakpoint extends Obj {
     breakpointNumber = json['breakpointNumber'];
     resolved = json['resolved'];
     isSyntheticAsyncContinuation = json['isSyntheticAsyncContinuation'];
-    location = createServiceObject(json['location']);
+    location = createServiceObject(json['location'], 'dynamic');
   }
 
   @override
@@ -2276,20 +2325,22 @@ class Class extends Obj {
 
   Class._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    error = createServiceObject(json['error']);
+    error = createServiceObject(json['error'], 'ErrorRef');
     isAbstract = json['abstract'];
     isConst = json['const'];
-    library = createServiceObject(json['library']);
-    location = createServiceObject(json['location']);
-    superClass = createServiceObject(json['super']);
-    superType = createServiceObject(json['superType']);
-    interfaces =
-        new List<InstanceRef>.from(createServiceObject(json['interfaces']));
-    mixin = createServiceObject(json['mixin']);
-    fields = new List<FieldRef>.from(createServiceObject(json['fields']));
-    functions = new List<FuncRef>.from(createServiceObject(json['functions']));
-    subclasses =
-        new List<ClassRef>.from(createServiceObject(json['subclasses']));
+    library = createServiceObject(json['library'], 'ObjRef');
+    location = createServiceObject(json['location'], 'SourceLocation');
+    superClass = createServiceObject(json['super'], 'ClassRef');
+    superType = createServiceObject(json['superType'], 'InstanceRef');
+    interfaces = new List<InstanceRef>.from(
+        createServiceObject(json['interfaces'], 'InstanceRef'));
+    mixin = createServiceObject(json['mixin'], 'InstanceRef');
+    fields = new List<FieldRef>.from(
+        createServiceObject(json['fields'], 'FieldRef'));
+    functions = new List<FuncRef>.from(
+        createServiceObject(json['functions'], 'FuncRef'));
+    subclasses = new List<ClassRef>.from(
+        createServiceObject(json['subclasses'], 'ClassRef'));
   }
 
   @override
@@ -2358,7 +2409,7 @@ class ClassHeapStats extends Response {
     bytesCurrent = json['bytesCurrent'];
     instancesAccumulated = json['instancesAccumulated'];
     instancesCurrent = json['instancesCurrent'];
-    classRef = createServiceObject(json['class']);
+    classRef = createServiceObject(json['class'], 'ClassRef');
     new_ = json['new'] == null ? null : new List<int>.from(json['new']);
     old = json['old'] == null ? null : new List<int>.from(json['old']);
     promotedBytes = json['promotedBytes'];
@@ -2395,7 +2446,8 @@ class ClassList extends Response {
   ClassList();
 
   ClassList._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    classes = new List<ClassRef>.from(createServiceObject(json['classes']));
+    classes = new List<ClassRef>.from(
+        createServiceObject(json['classes'], 'ClassRef'));
   }
 
   @override
@@ -2536,9 +2588,9 @@ class Context extends Obj {
 
   Context._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     length = json['length'];
-    parent = createServiceObject(json['parent']);
-    variables =
-        new List<ContextElement>.from(createServiceObject(json['variables']));
+    parent = createServiceObject(json['parent'], 'Context');
+    variables = new List<ContextElement>.from(
+        createServiceObject(json['variables'], 'ContextElement'));
   }
 
   @override
@@ -2571,7 +2623,7 @@ class ContextElement {
   ContextElement();
 
   ContextElement._fromJson(Map<String, dynamic> json) {
-    value = createServiceObject(json['value']);
+    value = createServiceObject(json['value'], 'dynamic');
   }
 
   Map<String, dynamic> toJson() {
@@ -2649,8 +2701,8 @@ class Error extends Obj {
   Error._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
     message = json['message'];
-    exception = createServiceObject(json['exception']);
-    stacktrace = createServiceObject(json['stacktrace']);
+    exception = createServiceObject(json['exception'], 'InstanceRef');
+    stacktrace = createServiceObject(json['stacktrace'], 'InstanceRef');
   }
 
   @override
@@ -2835,28 +2887,28 @@ class Event extends Response {
 
   Event._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
-    isolate = createServiceObject(json['isolate']);
-    vm = createServiceObject(json['vm']);
+    isolate = createServiceObject(json['isolate'], 'IsolateRef');
+    vm = createServiceObject(json['vm'], 'VMRef');
     timestamp = json['timestamp'];
-    breakpoint = createServiceObject(json['breakpoint']);
+    breakpoint = createServiceObject(json['breakpoint'], 'Breakpoint');
     pauseBreakpoints = json['pauseBreakpoints'] == null
         ? null
         : new List<Breakpoint>.from(
-            createServiceObject(json['pauseBreakpoints']));
-    topFrame = createServiceObject(json['topFrame']);
-    exception = createServiceObject(json['exception']);
+            createServiceObject(json['pauseBreakpoints'], 'Breakpoint'));
+    topFrame = createServiceObject(json['topFrame'], 'Frame');
+    exception = createServiceObject(json['exception'], 'InstanceRef');
     bytes = json['bytes'];
-    inspectee = createServiceObject(json['inspectee']);
+    inspectee = createServiceObject(json['inspectee'], 'InstanceRef');
     extensionRPC = json['extensionRPC'];
     extensionKind = json['extensionKind'];
     extensionData = ExtensionData.parse(json['extensionData']);
     timelineEvents = json['timelineEvents'] == null
         ? null
         : new List<TimelineEvent>.from(
-            createServiceObject(json['timelineEvents']));
+            createServiceObject(json['timelineEvents'], 'TimelineEvent'));
     atAsyncSuspension = json['atAsyncSuspension'];
     status = json['status'];
-    logRecord = createServiceObject(json['logRecord']);
+    logRecord = createServiceObject(json['logRecord'], 'LogRecord');
     service = json['service'];
     method = json['method'];
     alias = json['alias'];
@@ -2927,8 +2979,8 @@ class FieldRef extends ObjRef {
 
   FieldRef._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    owner = createServiceObject(json['owner']);
-    declaredType = createServiceObject(json['declaredType']);
+    owner = createServiceObject(json['owner'], 'ObjRef');
+    declaredType = createServiceObject(json['declaredType'], 'InstanceRef');
     isConst = json['const'];
     isFinal = json['final'];
     isStatic = json['static'];
@@ -2994,13 +3046,13 @@ class Field extends Obj {
 
   Field._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    owner = createServiceObject(json['owner']);
-    declaredType = createServiceObject(json['declaredType']);
+    owner = createServiceObject(json['owner'], 'ObjRef');
+    declaredType = createServiceObject(json['declaredType'], 'InstanceRef');
     isConst = json['const'];
     isFinal = json['final'];
     isStatic = json['static'];
-    staticValue = createServiceObject(json['staticValue']);
-    location = createServiceObject(json['location']);
+    staticValue = createServiceObject(json['staticValue'], 'InstanceRef');
+    location = createServiceObject(json['location'], 'SourceLocation');
   }
 
   @override
@@ -3082,7 +3134,7 @@ class FlagList extends Response {
   FlagList();
 
   FlagList._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    flags = new List<Flag>.from(createServiceObject(json['flags']));
+    flags = new List<Flag>.from(createServiceObject(json['flags'], 'Flag'));
   }
 
   @override
@@ -3124,12 +3176,13 @@ class Frame extends Response {
 
   Frame._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     index = json['index'];
-    function = createServiceObject(json['function']);
-    code = createServiceObject(json['code']);
-    location = createServiceObject(json['location']);
+    function = createServiceObject(json['function'], 'FuncRef');
+    code = createServiceObject(json['code'], 'CodeRef');
+    location = createServiceObject(json['location'], 'SourceLocation');
     vars = json['vars'] == null
         ? null
-        : new List<BoundVariable>.from(createServiceObject(json['vars']));
+        : new List<BoundVariable>.from(
+            createServiceObject(json['vars'], 'BoundVariable'));
     kind = json['kind'];
   }
 
@@ -3174,7 +3227,7 @@ class FuncRef extends ObjRef {
 
   FuncRef._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    owner = createServiceObject(json['owner']);
+    owner = createServiceObject(json['owner'], 'dynamic');
     isStatic = json['static'];
     isConst = json['const'];
   }
@@ -3226,9 +3279,9 @@ class Func extends Obj {
 
   Func._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    owner = createServiceObject(json['owner']);
-    location = createServiceObject(json['location']);
-    code = createServiceObject(json['code']);
+    owner = createServiceObject(json['owner'], 'dynamic');
+    location = createServiceObject(json['location'], 'SourceLocation');
+    code = createServiceObject(json['code'], 'CodeRef');
   }
 
   @override
@@ -3343,14 +3396,15 @@ class InstanceRef extends ObjRef {
 
   InstanceRef._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
-    classRef = createServiceObject(json['class']);
+    classRef = createServiceObject(json['class'], 'ClassRef');
     valueAsString = json['valueAsString'];
     valueAsStringIsTruncated = json['valueAsStringIsTruncated'] ?? false;
     length = json['length'];
     name = json['name'];
-    typeClass = createServiceObject(json['typeClass']);
-    parameterizedClass = createServiceObject(json['parameterizedClass']);
-    pattern = createServiceObject(json['pattern']);
+    typeClass = createServiceObject(json['typeClass'], 'ClassRef');
+    parameterizedClass =
+        createServiceObject(json['parameterizedClass'], 'ClassRef');
+    pattern = createServiceObject(json['pattern'], 'InstanceRef');
   }
 
   @override
@@ -3549,13 +3603,14 @@ class Instance extends Obj {
   @optional
   FuncRef closureFunction;
 
-  /// TODO(devoncarew): this can return an InstanceRef
-  ///
   /// The context associated with a Closure instance.
   ///
   /// Provided for instance kinds:
-  /// - Closure@Context closureContext [optional]; The referent of a
-  /// MirrorReference instance.
+  ///  - Closure
+  @optional
+  ContextRef closureContext;
+
+  /// The referent of a MirrorReference instance.
   ///
   /// Provided for instance kinds:
   ///  - MirrorReference
@@ -3638,37 +3693,42 @@ class Instance extends Obj {
 
   Instance._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
-    classRef = createServiceObject(json['class']);
+    classRef = createServiceObject(json['class'], 'ClassRef');
     valueAsString = json['valueAsString'];
     valueAsStringIsTruncated = json['valueAsStringIsTruncated'] ?? false;
     length = json['length'];
     offset = json['offset'];
     count = json['count'];
     name = json['name'];
-    typeClass = createServiceObject(json['typeClass']);
-    parameterizedClass = createServiceObject(json['parameterizedClass']);
+    typeClass = createServiceObject(json['typeClass'], 'ClassRef');
+    parameterizedClass =
+        createServiceObject(json['parameterizedClass'], 'ClassRef');
     fields = json['fields'] == null
         ? null
-        : new List<BoundField>.from(createServiceObject(json['fields']));
+        : new List<BoundField>.from(
+            createServiceObject(json['fields'], 'BoundField'));
     elements = json['elements'] == null
         ? null
-        : new List<dynamic>.from(createServiceObject(json['elements']));
+        : new List<dynamic>.from(
+            createServiceObject(json['elements'], 'dynamic'));
     associations = json['associations'] == null
         ? null
         : new List<MapAssociation>.from(
             _createSpecificObject(json['associations'], MapAssociation.parse));
     bytes = json['bytes'];
-    closureFunction = createServiceObject(json['closureFunction']);
-    mirrorReferent = createServiceObject(json['mirrorReferent']);
+    closureFunction = createServiceObject(json['closureFunction'], 'FuncRef');
+    closureContext = createServiceObject(json['closureContext'], 'ContextRef');
+    mirrorReferent = createServiceObject(json['mirrorReferent'], 'InstanceRef');
     pattern = json['pattern'];
     isCaseSensitive = json['isCaseSensitive'];
     isMultiLine = json['isMultiLine'];
-    propertyKey = createServiceObject(json['propertyKey']);
-    propertyValue = createServiceObject(json['propertyValue']);
-    typeArguments = createServiceObject(json['typeArguments']);
+    propertyKey = createServiceObject(json['propertyKey'], 'InstanceRef');
+    propertyValue = createServiceObject(json['propertyValue'], 'InstanceRef');
+    typeArguments =
+        createServiceObject(json['typeArguments'], 'TypeArgumentsRef');
     parameterIndex = json['parameterIndex'];
-    targetType = createServiceObject(json['targetType']);
-    bound = createServiceObject(json['bound']);
+    targetType = createServiceObject(json['targetType'], 'InstanceRef');
+    bound = createServiceObject(json['bound'], 'InstanceRef');
   }
 
   @override
@@ -3695,6 +3755,7 @@ class Instance extends Obj {
         json, 'associations', associations?.map((f) => f?.toJson())?.toList());
     _setIfNotNull(json, 'bytes', bytes);
     _setIfNotNull(json, 'closureFunction', closureFunction?.toJson());
+    _setIfNotNull(json, 'closureContext', closureContext?.toJson());
     _setIfNotNull(json, 'mirrorReferent', mirrorReferent?.toJson());
     _setIfNotNull(json, 'pattern', pattern);
     _setIfNotNull(json, 'isCaseSensitive', isCaseSensitive);
@@ -3826,13 +3887,13 @@ class Isolate extends Response {
     runnable = json['runnable'];
     livePorts = json['livePorts'];
     pauseOnExit = json['pauseOnExit'];
-    pauseEvent = createServiceObject(json['pauseEvent']);
-    rootLib = createServiceObject(json['rootLib']);
-    libraries =
-        new List<LibraryRef>.from(createServiceObject(json['libraries']));
-    breakpoints =
-        new List<Breakpoint>.from(createServiceObject(json['breakpoints']));
-    error = createServiceObject(json['error']);
+    pauseEvent = createServiceObject(json['pauseEvent'], 'Event');
+    rootLib = createServiceObject(json['rootLib'], 'LibraryRef');
+    libraries = new List<LibraryRef>.from(
+        createServiceObject(json['libraries'], 'LibraryRef'));
+    breakpoints = new List<Breakpoint>.from(
+        createServiceObject(json['breakpoints'], 'Breakpoint'));
+    error = createServiceObject(json['error'], 'Error');
     exceptionPauseMode = json['exceptionPauseMode'];
     extensionRPCs = json['extensionRPCs'] == null
         ? null
@@ -3886,7 +3947,7 @@ class InstanceSet extends Response {
   InstanceSet._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     totalCount = json['totalCount'];
     instances = new List<ObjRef>.from(
-        createServiceObject(json['instances'] ?? json['samples']));
+        createServiceObject(json['instances'] ?? json['samples'], 'ObjRef'));
   }
 
   @override
@@ -3980,10 +4041,14 @@ class Library extends Obj {
     debuggable = json['debuggable'];
     dependencies = new List<LibraryDependency>.from(
         _createSpecificObject(json['dependencies'], LibraryDependency.parse));
-    scripts = new List<ScriptRef>.from(createServiceObject(json['scripts']));
-    variables = new List<FieldRef>.from(createServiceObject(json['variables']));
-    functions = new List<FuncRef>.from(createServiceObject(json['functions']));
-    classes = new List<ClassRef>.from(createServiceObject(json['classes']));
+    scripts = new List<ScriptRef>.from(
+        createServiceObject(json['scripts'], 'ScriptRef'));
+    variables = new List<FieldRef>.from(
+        createServiceObject(json['variables'], 'FieldRef'));
+    functions = new List<FuncRef>.from(
+        createServiceObject(json['functions'], 'FuncRef'));
+    classes = new List<ClassRef>.from(
+        createServiceObject(json['classes'], 'ClassRef'));
   }
 
   @override
@@ -4033,7 +4098,7 @@ class LibraryDependency {
     isImport = json['isImport'];
     isDeferred = json['isDeferred'];
     prefix = json['prefix'];
-    target = createServiceObject(json['target']);
+    target = createServiceObject(json['target'], 'LibraryRef');
   }
 
   Map<String, dynamic> toJson() {
@@ -4086,14 +4151,14 @@ class LogRecord extends Response {
   LogRecord();
 
   LogRecord._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    message = createServiceObject(json['message']);
+    message = createServiceObject(json['message'], 'InstanceRef');
     time = json['time'];
     level = json['level'];
     sequenceNumber = json['sequenceNumber'];
-    loggerName = createServiceObject(json['loggerName']);
-    zone = createServiceObject(json['zone']);
-    error = createServiceObject(json['error']);
-    stackTrace = createServiceObject(json['stackTrace']);
+    loggerName = createServiceObject(json['loggerName'], 'InstanceRef');
+    zone = createServiceObject(json['zone'], 'InstanceRef');
+    error = createServiceObject(json['error'], 'InstanceRef');
+    stackTrace = createServiceObject(json['stackTrace'], 'InstanceRef');
   }
 
   @override
@@ -4129,8 +4194,8 @@ class MapAssociation {
   MapAssociation();
 
   MapAssociation._fromJson(Map<String, dynamic> json) {
-    key = createServiceObject(json['key']);
-    value = createServiceObject(json['value']);
+    key = createServiceObject(json['key'], 'dynamic');
+    value = createServiceObject(json['value'], 'dynamic');
   }
 
   Map<String, dynamic> toJson() {
@@ -4227,8 +4292,8 @@ class Message extends Response {
     name = json['name'];
     messageObjectId = json['messageObjectId'];
     size = json['size'];
-    handler = createServiceObject(json['handler']);
-    location = createServiceObject(json['location']);
+    handler = createServiceObject(json['handler'], 'FuncRef');
+    location = createServiceObject(json['location'], 'SourceLocation');
   }
 
   @override
@@ -4402,7 +4467,7 @@ class Obj extends Response {
   Obj._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     id = json['id'];
     fixedId = json['fixedId'];
-    classRef = createServiceObject(json['class']);
+    classRef = createServiceObject(json['class'], 'ClassRef');
     size = json['size'];
   }
 
@@ -4607,7 +4672,7 @@ class Script extends Obj {
 
   Script._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     uri = json['uri'];
-    library = createServiceObject(json['library']);
+    library = createServiceObject(json['library'], 'LibraryRef');
     lineOffset = json['lineOffset'];
     columnOffset = json['columnOffset'];
     source = json['source'];
@@ -4650,7 +4715,8 @@ class ScriptList extends Response {
   ScriptList();
 
   ScriptList._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    scripts = new List<ScriptRef>.from(createServiceObject(json['scripts']));
+    scripts = new List<ScriptRef>.from(
+        createServiceObject(json['scripts'], 'ScriptRef'));
   }
 
   @override
@@ -4685,7 +4751,7 @@ class SourceLocation extends Response {
   SourceLocation();
 
   SourceLocation._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    script = createServiceObject(json['script']);
+    script = createServiceObject(json['script'], 'ScriptRef');
     tokenPos = json['tokenPos'];
     endTokenPos = json['endTokenPos'];
   }
@@ -4730,7 +4796,8 @@ class SourceReport extends Response {
   SourceReport._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     ranges = new List<SourceReportRange>.from(
         _createSpecificObject(json['ranges'], SourceReportRange.parse));
-    scripts = new List<ScriptRef>.from(createServiceObject(json['scripts']));
+    scripts = new List<ScriptRef>.from(
+        createServiceObject(json['scripts'], 'ScriptRef'));
   }
 
   @override
@@ -4832,7 +4899,7 @@ class SourceReportRange {
     startPos = json['startPos'];
     endPos = json['endPos'];
     compiled = json['compiled'];
-    error = createServiceObject(json['error']);
+    error = createServiceObject(json['error'], 'ErrorRef');
     coverage =
         _createSpecificObject(json['coverage'], SourceReportCoverage.parse);
     possibleBreakpoints = json['possibleBreakpoints'] == null
@@ -4877,14 +4944,17 @@ class Stack extends Response {
   Stack();
 
   Stack._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    frames = new List<Frame>.from(createServiceObject(json['frames']));
+    frames = new List<Frame>.from(createServiceObject(json['frames'], 'Frame'));
     asyncCausalFrames = json['asyncCausalFrames'] == null
         ? null
-        : new List<Frame>.from(createServiceObject(json['asyncCausalFrames']));
+        : new List<Frame>.from(
+            createServiceObject(json['asyncCausalFrames'], 'Frame'));
     awaiterFrames = json['awaiterFrames'] == null
         ? null
-        : new List<Frame>.from(createServiceObject(json['awaiterFrames']));
-    messages = new List<Message>.from(createServiceObject(json['messages']));
+        : new List<Frame>.from(
+            createServiceObject(json['awaiterFrames'], 'Frame'));
+    messages = new List<Message>.from(
+        createServiceObject(json['messages'], 'Message'));
   }
 
   @override
@@ -4942,8 +5012,8 @@ class Timeline extends Response {
   Timeline();
 
   Timeline._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    traceEvents =
-        new List<TimelineEvent>.from(createServiceObject(json['traceEvents']));
+    traceEvents = new List<TimelineEvent>.from(
+        createServiceObject(json['traceEvents'], 'TimelineEvent'));
     timeOriginMicros = json['timeOriginMicros'];
     timeExtentMicros = json['timeExtentMicros'];
   }
@@ -5101,7 +5171,8 @@ class TypeArguments extends Obj {
 
   TypeArguments._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    types = new List<InstanceRef>.from(createServiceObject(json['types']));
+    types = new List<InstanceRef>.from(
+        createServiceObject(json['types'], 'InstanceRef'));
   }
 
   @override
@@ -5165,7 +5236,7 @@ class UnresolvedSourceLocation extends Response {
 
   UnresolvedSourceLocation._fromJson(Map<String, dynamic> json)
       : super._fromJson(json) {
-    script = createServiceObject(json['script']);
+    script = createServiceObject(json['script'], 'ScriptRef');
     scriptUri = json['scriptUri'];
     tokenPos = json['tokenPos'];
     line = json['line'];
@@ -5289,7 +5360,8 @@ class VM extends Response {
     version = json['version'];
     pid = json['pid'];
     startTime = json['startTime'];
-    isolates = new List<IsolateRef>.from(createServiceObject(json['isolates']));
+    isolates = new List<IsolateRef>.from(
+        createServiceObject(json['isolates'], 'IsolateRef'));
   }
 
   @override
@@ -5402,7 +5474,7 @@ class CodeRegion {
     kind = json['kind'];
     inclusiveTicks = json['inclusiveTicks'];
     exclusiveTicks = json['exclusiveTicks'];
-    code = createServiceObject(json['code']);
+    code = createServiceObject(json['code'], 'CodeRef');
   }
 
   Map<String, dynamic> toJson() {
@@ -5441,7 +5513,7 @@ class ProfileFunction {
     kind = json['kind'];
     inclusiveTicks = json['inclusiveTicks'];
     exclusiveTicks = json['exclusiveTicks'];
-    function = createServiceObject(json['function']);
+    function = createServiceObject(json['function'], 'FuncRef');
     codes = new List<int>.from(json['codes']);
   }
 

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -33,14 +33,14 @@ String decodeBase64(String str) => utf8.decode(base64.decode(str));
 bool _isNullInstance(Map json) =>
     ((json['type'] == '@Instance') && (json['kind'] == 'Null'));
 
-Object createServiceObject(dynamic json, [String expectedType]) {
+Object createServiceObject(dynamic json, [List<String> expectedTypes]) {
   if (json == null) return null;
 
   if (json is List) {
-    return json.map((e) => createServiceObject(e, expectedType)).toList();
+    return json.map((e) => createServiceObject(e, expectedTypes)).toList();
   } else if (json is Map) {
     String type = json['type'];
-    if (_isNullInstance(json) && (expectedType != type)) {
+    if (_isNullInstance(json) && (!expectedTypes.contains(type))) {
       return null;
     }
     if (_typeFactories[type] == null) {
@@ -149,46 +149,46 @@ Map<String, Function> _typeFactories = {
   'HeapSpace': HeapSpace.parse,
 };
 
-Map<String, String> _methodReturnTypes = {
-  'addBreakpoint': 'Breakpoint',
-  'addBreakpointWithScriptUri': 'Breakpoint',
-  'addBreakpointAtEntry': 'Breakpoint',
-  'clearVMTimeline': 'Success',
-  'invoke': 'dynamic',
-  'evaluate': 'dynamic',
-  'evaluateInFrame': 'dynamic',
-  'getAllocationProfile': 'AllocationProfile',
-  'getFlagList': 'FlagList',
-  'getInstances': 'InstanceSet',
-  'getIsolate': 'dynamic',
-  'getMemoryUsage': 'dynamic',
-  'getScripts': 'ScriptList',
-  'getObject': 'dynamic',
-  'getStack': 'Stack',
-  'getSourceReport': 'SourceReport',
-  'getVersion': 'Version',
-  'getVM': 'VM',
-  'getVMTimeline': 'Timeline',
-  'getVMTimelineFlags': 'TimelineFlags',
-  'getVMTimelineMicros': 'Timestamp',
-  'pause': 'Success',
-  'kill': 'Success',
-  'reloadSources': 'ReloadReport',
-  'removeBreakpoint': 'Success',
-  'resume': 'Success',
-  'setExceptionPauseMode': 'Success',
-  'setFlag': 'Success',
-  'setLibraryDebuggable': 'Success',
-  'setName': 'Success',
-  'setVMName': 'Success',
-  'setVMTimelineFlags': 'Success',
-  'streamCancel': 'Success',
-  'streamListen': 'Success',
-  '_collectAllGarbage': 'Success',
-  '_requestHeapSnapshot': 'Success',
-  '_clearCpuProfile': 'Success',
-  '_getCpuProfile': 'CpuProfile',
-  '_registerService': 'Success',
+Map<String, List<String>> _methodReturnTypes = {
+  'addBreakpoint': ['Breakpoint'],
+  'addBreakpointWithScriptUri': ['Breakpoint'],
+  'addBreakpointAtEntry': ['Breakpoint'],
+  'clearVMTimeline': ['Success'],
+  'invoke': ['InstanceRef', 'ErrorRef', 'Sentinel'],
+  'evaluate': ['InstanceRef', 'ErrorRef', 'Sentinel'],
+  'evaluateInFrame': ['InstanceRef', 'ErrorRef', 'Sentinel'],
+  'getAllocationProfile': ['AllocationProfile'],
+  'getFlagList': ['FlagList'],
+  'getInstances': ['InstanceSet'],
+  'getIsolate': ['Isolate', 'Sentinel'],
+  'getMemoryUsage': ['MemoryUsage', 'Sentinel'],
+  'getScripts': ['ScriptList'],
+  'getObject': ['Obj', 'Sentinel'],
+  'getStack': ['Stack'],
+  'getSourceReport': ['SourceReport'],
+  'getVersion': ['Version'],
+  'getVM': ['VM'],
+  'getVMTimeline': ['Timeline'],
+  'getVMTimelineFlags': ['TimelineFlags'],
+  'getVMTimelineMicros': ['Timestamp'],
+  'pause': ['Success'],
+  'kill': ['Success'],
+  'reloadSources': ['ReloadReport'],
+  'removeBreakpoint': ['Success'],
+  'resume': ['Success'],
+  'setExceptionPauseMode': ['Success'],
+  'setFlag': ['Success'],
+  'setLibraryDebuggable': ['Success'],
+  'setName': ['Success'],
+  'setVMName': ['Success'],
+  'setVMTimelineFlags': ['Success'],
+  'streamCancel': ['Success'],
+  'streamListen': ['Success'],
+  '_collectAllGarbage': ['Success'],
+  '_requestHeapSnapshot': ['Success'],
+  '_clearCpuProfile': ['Success'],
+  '_getCpuProfile': ['_CpuProfile'],
+  '_registerService': ['Success'],
 };
 
 /// A class representation of the Dart VM Service Protocol.
@@ -1630,7 +1630,7 @@ class VmService implements VmServiceInterface {
   void _processResponse(Map<String, dynamic> json) {
     Completer completer = _completers.remove(json['id']);
     String methodName = _methodCalls.remove(json['id']);
-    String returnType = _methodReturnTypes[methodName];
+    List<String> returnTypes = _methodReturnTypes[methodName];
     if (completer == null) {
       _log.severe('unmatched request response: ${jsonEncode(json)}');
     } else if (json['error'] != null) {
@@ -1641,7 +1641,7 @@ class VmService implements VmServiceInterface {
       if (_typeFactories[type] == null) {
         completer.complete(Response.parse(result));
       } else {
-        completer.complete(createServiceObject(result, returnType));
+        completer.complete(createServiceObject(result, returnTypes));
       }
     }
   }
@@ -2052,7 +2052,7 @@ class AllocationProfile extends Response {
 
   AllocationProfile._fromJson(Map<String, dynamic> json)
       : super._fromJson(json) {
-    memoryUsage = createServiceObject(json['memoryUsage'], 'MemoryUsage');
+    memoryUsage = createServiceObject(json['memoryUsage'], ['MemoryUsage']);
     dateLastAccumulatorReset = json['dateLastAccumulatorReset'] is String
         ? int.parse(json['dateLastAccumulatorReset'])
         : json['dateLastAccumulatorReset'];
@@ -2060,7 +2060,7 @@ class AllocationProfile extends Response {
         ? int.parse(json['dateLastServiceGC'])
         : json['dateLastServiceGC'];
     members = new List<ClassHeapStats>.from(
-        createServiceObject(json['members'], 'ClassHeapStats'));
+        createServiceObject(json['members'], ['ClassHeapStats']));
   }
 
   @override
@@ -2100,8 +2100,8 @@ class BoundField {
   BoundField();
 
   BoundField._fromJson(Map<String, dynamic> json) {
-    decl = createServiceObject(json['decl'], 'FieldRef');
-    value = createServiceObject(json['value'], 'dynamic');
+    decl = createServiceObject(json['decl'], ['FieldRef']);
+    value = createServiceObject(json['value'], ['InstanceRef', 'Sentinel']);
   }
 
   Map<String, dynamic> toJson() {
@@ -2149,7 +2149,8 @@ class BoundVariable extends Response {
 
   BoundVariable._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    value = createServiceObject(json['value'], 'dynamic');
+    value = createServiceObject(
+        json['value'], ['InstanceRef', 'TypeArgumentsRef', 'Sentinel']);
     declarationTokenPos = json['declarationTokenPos'];
     scopeStartTokenPos = json['scopeStartTokenPos'];
     scopeEndTokenPos = json['scopeEndTokenPos'];
@@ -2207,7 +2208,8 @@ class Breakpoint extends Obj {
     breakpointNumber = json['breakpointNumber'];
     resolved = json['resolved'];
     isSyntheticAsyncContinuation = json['isSyntheticAsyncContinuation'];
-    location = createServiceObject(json['location'], 'dynamic');
+    location = createServiceObject(
+        json['location'], ['SourceLocation', 'UnresolvedSourceLocation']);
   }
 
   @override
@@ -2325,22 +2327,22 @@ class Class extends Obj {
 
   Class._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    error = createServiceObject(json['error'], 'ErrorRef');
+    error = createServiceObject(json['error'], ['ErrorRef']);
     isAbstract = json['abstract'];
     isConst = json['const'];
-    library = createServiceObject(json['library'], 'ObjRef');
-    location = createServiceObject(json['location'], 'SourceLocation');
-    superClass = createServiceObject(json['super'], 'ClassRef');
-    superType = createServiceObject(json['superType'], 'InstanceRef');
+    library = createServiceObject(json['library'], ['ObjRef']);
+    location = createServiceObject(json['location'], ['SourceLocation']);
+    superClass = createServiceObject(json['super'], ['ClassRef']);
+    superType = createServiceObject(json['superType'], ['InstanceRef']);
     interfaces = new List<InstanceRef>.from(
-        createServiceObject(json['interfaces'], 'InstanceRef'));
-    mixin = createServiceObject(json['mixin'], 'InstanceRef');
+        createServiceObject(json['interfaces'], ['InstanceRef']));
+    mixin = createServiceObject(json['mixin'], ['InstanceRef']);
     fields = new List<FieldRef>.from(
-        createServiceObject(json['fields'], 'FieldRef'));
+        createServiceObject(json['fields'], ['FieldRef']));
     functions = new List<FuncRef>.from(
-        createServiceObject(json['functions'], 'FuncRef'));
+        createServiceObject(json['functions'], ['FuncRef']));
     subclasses = new List<ClassRef>.from(
-        createServiceObject(json['subclasses'], 'ClassRef'));
+        createServiceObject(json['subclasses'], ['ClassRef']));
   }
 
   @override
@@ -2409,7 +2411,7 @@ class ClassHeapStats extends Response {
     bytesCurrent = json['bytesCurrent'];
     instancesAccumulated = json['instancesAccumulated'];
     instancesCurrent = json['instancesCurrent'];
-    classRef = createServiceObject(json['class'], 'ClassRef');
+    classRef = createServiceObject(json['class'], ['ClassRef']);
     new_ = json['new'] == null ? null : new List<int>.from(json['new']);
     old = json['old'] == null ? null : new List<int>.from(json['old']);
     promotedBytes = json['promotedBytes'];
@@ -2447,7 +2449,7 @@ class ClassList extends Response {
 
   ClassList._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     classes = new List<ClassRef>.from(
-        createServiceObject(json['classes'], 'ClassRef'));
+        createServiceObject(json['classes'], ['ClassRef']));
   }
 
   @override
@@ -2588,9 +2590,9 @@ class Context extends Obj {
 
   Context._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     length = json['length'];
-    parent = createServiceObject(json['parent'], 'Context');
+    parent = createServiceObject(json['parent'], ['Context']);
     variables = new List<ContextElement>.from(
-        createServiceObject(json['variables'], 'ContextElement'));
+        createServiceObject(json['variables'], ['ContextElement']));
   }
 
   @override
@@ -2623,7 +2625,7 @@ class ContextElement {
   ContextElement();
 
   ContextElement._fromJson(Map<String, dynamic> json) {
-    value = createServiceObject(json['value'], 'dynamic');
+    value = createServiceObject(json['value'], ['InstanceRef', 'Sentinel']);
   }
 
   Map<String, dynamic> toJson() {
@@ -2701,8 +2703,8 @@ class Error extends Obj {
   Error._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
     message = json['message'];
-    exception = createServiceObject(json['exception'], 'InstanceRef');
-    stacktrace = createServiceObject(json['stacktrace'], 'InstanceRef');
+    exception = createServiceObject(json['exception'], ['InstanceRef']);
+    stacktrace = createServiceObject(json['stacktrace'], ['InstanceRef']);
   }
 
   @override
@@ -2887,28 +2889,28 @@ class Event extends Response {
 
   Event._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
-    isolate = createServiceObject(json['isolate'], 'IsolateRef');
-    vm = createServiceObject(json['vm'], 'VMRef');
+    isolate = createServiceObject(json['isolate'], ['IsolateRef']);
+    vm = createServiceObject(json['vm'], ['VMRef']);
     timestamp = json['timestamp'];
-    breakpoint = createServiceObject(json['breakpoint'], 'Breakpoint');
+    breakpoint = createServiceObject(json['breakpoint'], ['Breakpoint']);
     pauseBreakpoints = json['pauseBreakpoints'] == null
         ? null
         : new List<Breakpoint>.from(
-            createServiceObject(json['pauseBreakpoints'], 'Breakpoint'));
-    topFrame = createServiceObject(json['topFrame'], 'Frame');
-    exception = createServiceObject(json['exception'], 'InstanceRef');
+            createServiceObject(json['pauseBreakpoints'], ['Breakpoint']));
+    topFrame = createServiceObject(json['topFrame'], ['Frame']);
+    exception = createServiceObject(json['exception'], ['InstanceRef']);
     bytes = json['bytes'];
-    inspectee = createServiceObject(json['inspectee'], 'InstanceRef');
+    inspectee = createServiceObject(json['inspectee'], ['InstanceRef']);
     extensionRPC = json['extensionRPC'];
     extensionKind = json['extensionKind'];
     extensionData = ExtensionData.parse(json['extensionData']);
     timelineEvents = json['timelineEvents'] == null
         ? null
         : new List<TimelineEvent>.from(
-            createServiceObject(json['timelineEvents'], 'TimelineEvent'));
+            createServiceObject(json['timelineEvents'], ['TimelineEvent']));
     atAsyncSuspension = json['atAsyncSuspension'];
     status = json['status'];
-    logRecord = createServiceObject(json['logRecord'], 'LogRecord');
+    logRecord = createServiceObject(json['logRecord'], ['LogRecord']);
     service = json['service'];
     method = json['method'];
     alias = json['alias'];
@@ -2979,8 +2981,8 @@ class FieldRef extends ObjRef {
 
   FieldRef._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    owner = createServiceObject(json['owner'], 'ObjRef');
-    declaredType = createServiceObject(json['declaredType'], 'InstanceRef');
+    owner = createServiceObject(json['owner'], ['ObjRef']);
+    declaredType = createServiceObject(json['declaredType'], ['InstanceRef']);
     isConst = json['const'];
     isFinal = json['final'];
     isStatic = json['static'];
@@ -3046,13 +3048,13 @@ class Field extends Obj {
 
   Field._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    owner = createServiceObject(json['owner'], 'ObjRef');
-    declaredType = createServiceObject(json['declaredType'], 'InstanceRef');
+    owner = createServiceObject(json['owner'], ['ObjRef']);
+    declaredType = createServiceObject(json['declaredType'], ['InstanceRef']);
     isConst = json['const'];
     isFinal = json['final'];
     isStatic = json['static'];
-    staticValue = createServiceObject(json['staticValue'], 'InstanceRef');
-    location = createServiceObject(json['location'], 'SourceLocation');
+    staticValue = createServiceObject(json['staticValue'], ['InstanceRef']);
+    location = createServiceObject(json['location'], ['SourceLocation']);
   }
 
   @override
@@ -3134,7 +3136,7 @@ class FlagList extends Response {
   FlagList();
 
   FlagList._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    flags = new List<Flag>.from(createServiceObject(json['flags'], 'Flag'));
+    flags = new List<Flag>.from(createServiceObject(json['flags'], ['Flag']));
   }
 
   @override
@@ -3176,13 +3178,13 @@ class Frame extends Response {
 
   Frame._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     index = json['index'];
-    function = createServiceObject(json['function'], 'FuncRef');
-    code = createServiceObject(json['code'], 'CodeRef');
-    location = createServiceObject(json['location'], 'SourceLocation');
+    function = createServiceObject(json['function'], ['FuncRef']);
+    code = createServiceObject(json['code'], ['CodeRef']);
+    location = createServiceObject(json['location'], ['SourceLocation']);
     vars = json['vars'] == null
         ? null
         : new List<BoundVariable>.from(
-            createServiceObject(json['vars'], 'BoundVariable'));
+            createServiceObject(json['vars'], ['BoundVariable']));
     kind = json['kind'];
   }
 
@@ -3227,7 +3229,8 @@ class FuncRef extends ObjRef {
 
   FuncRef._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    owner = createServiceObject(json['owner'], 'dynamic');
+    owner = createServiceObject(
+        json['owner'], ['LibraryRef', 'ClassRef', 'FuncRef']);
     isStatic = json['static'];
     isConst = json['const'];
   }
@@ -3279,9 +3282,10 @@ class Func extends Obj {
 
   Func._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
-    owner = createServiceObject(json['owner'], 'dynamic');
-    location = createServiceObject(json['location'], 'SourceLocation');
-    code = createServiceObject(json['code'], 'CodeRef');
+    owner = createServiceObject(
+        json['owner'], ['LibraryRef', 'ClassRef', 'FuncRef']);
+    location = createServiceObject(json['location'], ['SourceLocation']);
+    code = createServiceObject(json['code'], ['CodeRef']);
   }
 
   @override
@@ -3396,15 +3400,15 @@ class InstanceRef extends ObjRef {
 
   InstanceRef._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
-    classRef = createServiceObject(json['class'], 'ClassRef');
+    classRef = createServiceObject(json['class'], ['ClassRef']);
     valueAsString = json['valueAsString'];
     valueAsStringIsTruncated = json['valueAsStringIsTruncated'] ?? false;
     length = json['length'];
     name = json['name'];
-    typeClass = createServiceObject(json['typeClass'], 'ClassRef');
+    typeClass = createServiceObject(json['typeClass'], ['ClassRef']);
     parameterizedClass =
-        createServiceObject(json['parameterizedClass'], 'ClassRef');
-    pattern = createServiceObject(json['pattern'], 'InstanceRef');
+        createServiceObject(json['parameterizedClass'], ['ClassRef']);
+    pattern = createServiceObject(json['pattern'], ['InstanceRef']);
   }
 
   @override
@@ -3693,42 +3697,44 @@ class Instance extends Obj {
 
   Instance._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     kind = json['kind'];
-    classRef = createServiceObject(json['class'], 'ClassRef');
+    classRef = createServiceObject(json['class'], ['ClassRef']);
     valueAsString = json['valueAsString'];
     valueAsStringIsTruncated = json['valueAsStringIsTruncated'] ?? false;
     length = json['length'];
     offset = json['offset'];
     count = json['count'];
     name = json['name'];
-    typeClass = createServiceObject(json['typeClass'], 'ClassRef');
+    typeClass = createServiceObject(json['typeClass'], ['ClassRef']);
     parameterizedClass =
-        createServiceObject(json['parameterizedClass'], 'ClassRef');
+        createServiceObject(json['parameterizedClass'], ['ClassRef']);
     fields = json['fields'] == null
         ? null
         : new List<BoundField>.from(
-            createServiceObject(json['fields'], 'BoundField'));
+            createServiceObject(json['fields'], ['BoundField']));
     elements = json['elements'] == null
         ? null
         : new List<dynamic>.from(
-            createServiceObject(json['elements'], 'dynamic'));
+            createServiceObject(json['elements'], ['dynamic']));
     associations = json['associations'] == null
         ? null
         : new List<MapAssociation>.from(
             _createSpecificObject(json['associations'], MapAssociation.parse));
     bytes = json['bytes'];
-    closureFunction = createServiceObject(json['closureFunction'], 'FuncRef');
-    closureContext = createServiceObject(json['closureContext'], 'ContextRef');
-    mirrorReferent = createServiceObject(json['mirrorReferent'], 'InstanceRef');
+    closureFunction = createServiceObject(json['closureFunction'], ['FuncRef']);
+    closureContext =
+        createServiceObject(json['closureContext'], ['ContextRef']);
+    mirrorReferent =
+        createServiceObject(json['mirrorReferent'], ['InstanceRef']);
     pattern = json['pattern'];
     isCaseSensitive = json['isCaseSensitive'];
     isMultiLine = json['isMultiLine'];
-    propertyKey = createServiceObject(json['propertyKey'], 'InstanceRef');
-    propertyValue = createServiceObject(json['propertyValue'], 'InstanceRef');
+    propertyKey = createServiceObject(json['propertyKey'], ['InstanceRef']);
+    propertyValue = createServiceObject(json['propertyValue'], ['InstanceRef']);
     typeArguments =
-        createServiceObject(json['typeArguments'], 'TypeArgumentsRef');
+        createServiceObject(json['typeArguments'], ['TypeArgumentsRef']);
     parameterIndex = json['parameterIndex'];
-    targetType = createServiceObject(json['targetType'], 'InstanceRef');
-    bound = createServiceObject(json['bound'], 'InstanceRef');
+    targetType = createServiceObject(json['targetType'], ['InstanceRef']);
+    bound = createServiceObject(json['bound'], ['InstanceRef']);
   }
 
   @override
@@ -3887,13 +3893,13 @@ class Isolate extends Response {
     runnable = json['runnable'];
     livePorts = json['livePorts'];
     pauseOnExit = json['pauseOnExit'];
-    pauseEvent = createServiceObject(json['pauseEvent'], 'Event');
-    rootLib = createServiceObject(json['rootLib'], 'LibraryRef');
+    pauseEvent = createServiceObject(json['pauseEvent'], ['Event']);
+    rootLib = createServiceObject(json['rootLib'], ['LibraryRef']);
     libraries = new List<LibraryRef>.from(
-        createServiceObject(json['libraries'], 'LibraryRef'));
+        createServiceObject(json['libraries'], ['LibraryRef']));
     breakpoints = new List<Breakpoint>.from(
-        createServiceObject(json['breakpoints'], 'Breakpoint'));
-    error = createServiceObject(json['error'], 'Error');
+        createServiceObject(json['breakpoints'], ['Breakpoint']));
+    error = createServiceObject(json['error'], ['Error']);
     exceptionPauseMode = json['exceptionPauseMode'];
     extensionRPCs = json['extensionRPCs'] == null
         ? null
@@ -3947,7 +3953,7 @@ class InstanceSet extends Response {
   InstanceSet._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     totalCount = json['totalCount'];
     instances = new List<ObjRef>.from(
-        createServiceObject(json['instances'] ?? json['samples'], 'ObjRef'));
+        createServiceObject(json['instances'] ?? json['samples'], ['ObjRef']));
   }
 
   @override
@@ -4042,13 +4048,13 @@ class Library extends Obj {
     dependencies = new List<LibraryDependency>.from(
         _createSpecificObject(json['dependencies'], LibraryDependency.parse));
     scripts = new List<ScriptRef>.from(
-        createServiceObject(json['scripts'], 'ScriptRef'));
+        createServiceObject(json['scripts'], ['ScriptRef']));
     variables = new List<FieldRef>.from(
-        createServiceObject(json['variables'], 'FieldRef'));
+        createServiceObject(json['variables'], ['FieldRef']));
     functions = new List<FuncRef>.from(
-        createServiceObject(json['functions'], 'FuncRef'));
+        createServiceObject(json['functions'], ['FuncRef']));
     classes = new List<ClassRef>.from(
-        createServiceObject(json['classes'], 'ClassRef'));
+        createServiceObject(json['classes'], ['ClassRef']));
   }
 
   @override
@@ -4098,7 +4104,7 @@ class LibraryDependency {
     isImport = json['isImport'];
     isDeferred = json['isDeferred'];
     prefix = json['prefix'];
-    target = createServiceObject(json['target'], 'LibraryRef');
+    target = createServiceObject(json['target'], ['LibraryRef']);
   }
 
   Map<String, dynamic> toJson() {
@@ -4151,14 +4157,14 @@ class LogRecord extends Response {
   LogRecord();
 
   LogRecord._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    message = createServiceObject(json['message'], 'InstanceRef');
+    message = createServiceObject(json['message'], ['InstanceRef']);
     time = json['time'];
     level = json['level'];
     sequenceNumber = json['sequenceNumber'];
-    loggerName = createServiceObject(json['loggerName'], 'InstanceRef');
-    zone = createServiceObject(json['zone'], 'InstanceRef');
-    error = createServiceObject(json['error'], 'InstanceRef');
-    stackTrace = createServiceObject(json['stackTrace'], 'InstanceRef');
+    loggerName = createServiceObject(json['loggerName'], ['InstanceRef']);
+    zone = createServiceObject(json['zone'], ['InstanceRef']);
+    error = createServiceObject(json['error'], ['InstanceRef']);
+    stackTrace = createServiceObject(json['stackTrace'], ['InstanceRef']);
   }
 
   @override
@@ -4194,8 +4200,8 @@ class MapAssociation {
   MapAssociation();
 
   MapAssociation._fromJson(Map<String, dynamic> json) {
-    key = createServiceObject(json['key'], 'dynamic');
-    value = createServiceObject(json['value'], 'dynamic');
+    key = createServiceObject(json['key'], ['InstanceRef', 'Sentinel']);
+    value = createServiceObject(json['value'], ['InstanceRef', 'Sentinel']);
   }
 
   Map<String, dynamic> toJson() {
@@ -4292,8 +4298,8 @@ class Message extends Response {
     name = json['name'];
     messageObjectId = json['messageObjectId'];
     size = json['size'];
-    handler = createServiceObject(json['handler'], 'FuncRef');
-    location = createServiceObject(json['location'], 'SourceLocation');
+    handler = createServiceObject(json['handler'], ['FuncRef']);
+    location = createServiceObject(json['location'], ['SourceLocation']);
   }
 
   @override
@@ -4467,7 +4473,7 @@ class Obj extends Response {
   Obj._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     id = json['id'];
     fixedId = json['fixedId'];
-    classRef = createServiceObject(json['class'], 'ClassRef');
+    classRef = createServiceObject(json['class'], ['ClassRef']);
     size = json['size'];
   }
 
@@ -4672,7 +4678,7 @@ class Script extends Obj {
 
   Script._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     uri = json['uri'];
-    library = createServiceObject(json['library'], 'LibraryRef');
+    library = createServiceObject(json['library'], ['LibraryRef']);
     lineOffset = json['lineOffset'];
     columnOffset = json['columnOffset'];
     source = json['source'];
@@ -4716,7 +4722,7 @@ class ScriptList extends Response {
 
   ScriptList._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     scripts = new List<ScriptRef>.from(
-        createServiceObject(json['scripts'], 'ScriptRef'));
+        createServiceObject(json['scripts'], ['ScriptRef']));
   }
 
   @override
@@ -4751,7 +4757,7 @@ class SourceLocation extends Response {
   SourceLocation();
 
   SourceLocation._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    script = createServiceObject(json['script'], 'ScriptRef');
+    script = createServiceObject(json['script'], ['ScriptRef']);
     tokenPos = json['tokenPos'];
     endTokenPos = json['endTokenPos'];
   }
@@ -4797,7 +4803,7 @@ class SourceReport extends Response {
     ranges = new List<SourceReportRange>.from(
         _createSpecificObject(json['ranges'], SourceReportRange.parse));
     scripts = new List<ScriptRef>.from(
-        createServiceObject(json['scripts'], 'ScriptRef'));
+        createServiceObject(json['scripts'], ['ScriptRef']));
   }
 
   @override
@@ -4899,7 +4905,7 @@ class SourceReportRange {
     startPos = json['startPos'];
     endPos = json['endPos'];
     compiled = json['compiled'];
-    error = createServiceObject(json['error'], 'ErrorRef');
+    error = createServiceObject(json['error'], ['ErrorRef']);
     coverage =
         _createSpecificObject(json['coverage'], SourceReportCoverage.parse);
     possibleBreakpoints = json['possibleBreakpoints'] == null
@@ -4944,17 +4950,18 @@ class Stack extends Response {
   Stack();
 
   Stack._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
-    frames = new List<Frame>.from(createServiceObject(json['frames'], 'Frame'));
+    frames =
+        new List<Frame>.from(createServiceObject(json['frames'], ['Frame']));
     asyncCausalFrames = json['asyncCausalFrames'] == null
         ? null
         : new List<Frame>.from(
-            createServiceObject(json['asyncCausalFrames'], 'Frame'));
+            createServiceObject(json['asyncCausalFrames'], ['Frame']));
     awaiterFrames = json['awaiterFrames'] == null
         ? null
         : new List<Frame>.from(
-            createServiceObject(json['awaiterFrames'], 'Frame'));
+            createServiceObject(json['awaiterFrames'], ['Frame']));
     messages = new List<Message>.from(
-        createServiceObject(json['messages'], 'Message'));
+        createServiceObject(json['messages'], ['Message']));
   }
 
   @override
@@ -5013,7 +5020,7 @@ class Timeline extends Response {
 
   Timeline._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     traceEvents = new List<TimelineEvent>.from(
-        createServiceObject(json['traceEvents'], 'TimelineEvent'));
+        createServiceObject(json['traceEvents'], ['TimelineEvent']));
     timeOriginMicros = json['timeOriginMicros'];
     timeExtentMicros = json['timeExtentMicros'];
   }
@@ -5172,7 +5179,7 @@ class TypeArguments extends Obj {
   TypeArguments._fromJson(Map<String, dynamic> json) : super._fromJson(json) {
     name = json['name'];
     types = new List<InstanceRef>.from(
-        createServiceObject(json['types'], 'InstanceRef'));
+        createServiceObject(json['types'], ['InstanceRef']));
   }
 
   @override
@@ -5236,7 +5243,7 @@ class UnresolvedSourceLocation extends Response {
 
   UnresolvedSourceLocation._fromJson(Map<String, dynamic> json)
       : super._fromJson(json) {
-    script = createServiceObject(json['script'], 'ScriptRef');
+    script = createServiceObject(json['script'], ['ScriptRef']);
     scriptUri = json['scriptUri'];
     tokenPos = json['tokenPos'];
     line = json['line'];
@@ -5361,7 +5368,7 @@ class VM extends Response {
     pid = json['pid'];
     startTime = json['startTime'];
     isolates = new List<IsolateRef>.from(
-        createServiceObject(json['isolates'], 'IsolateRef'));
+        createServiceObject(json['isolates'], ['IsolateRef']));
   }
 
   @override
@@ -5474,7 +5481,7 @@ class CodeRegion {
     kind = json['kind'];
     inclusiveTicks = json['inclusiveTicks'];
     exclusiveTicks = json['exclusiveTicks'];
-    code = createServiceObject(json['code'], 'CodeRef');
+    code = createServiceObject(json['code'], ['CodeRef']);
   }
 
   Map<String, dynamic> toJson() {
@@ -5513,7 +5520,7 @@ class ProfileFunction {
     kind = json['kind'];
     inclusiveTicks = json['inclusiveTicks'];
     exclusiveTicks = json['exclusiveTicks'];
-    function = createServiceObject(json['function'], 'FuncRef');
+    function = createServiceObject(json['function'], ['FuncRef']);
     codes = new List<int>.from(json['codes']);
   }
 

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 3.21.0
+version: 3.21.1
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers

--- a/dart/tool/common/src_gen_common.dart
+++ b/dart/tool/common/src_gen_common.dart
@@ -22,8 +22,10 @@ bool isPre(Node node) => node is Element && node.tag == 'pre';
 bool isH1(Node node) => node is Element && node.tag == 'h1';
 bool isH3(Node node) => node is Element && node.tag == 'h3';
 bool isHeader(Node node) => node is Element && node.tag.startsWith('h');
-String textForElement(Node node) => (((node as Element).children.first) as Text).text;
-String textForCode(Node node) => textForElement((node as Element).children.first);
+String textForElement(Node node) =>
+    (((node as Element).children.first) as Text).text;
+String textForCode(Node node) =>
+    textForElement((node as Element).children.first);
 
 /// foo ==> Foo
 String titleCase(String str) =>

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -513,6 +513,13 @@ typedef ServiceCallback = Future<Map<String, dynamic>> Function(
     gen.writeln('};');
     gen.writeln();
 
+    gen.writeln('Map<String, String> _methodReturnTypes = {');
+    methods.forEach((Method method) {
+      gen.writeln("'${method.name}' : '${method.returnType.name}',");
+    });
+    gen.writeln('};');
+    gen.writeln();
+
     // The service interface, both servers and clients implement this.
     gen.writeStatement('''
 /// A class representation of the Dart VM Service Protocol.

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -147,7 +147,7 @@ final String _implCode = r'''
       String streamId = map['params']['streamId'];
       Map event = map['params']['event'];
       event['_data'] = data;
-      _getEventController(streamId).add(createServiceObject(event));
+      _getEventController(streamId).add(createServiceObject(event, const ['Event']));
     }
   }
 
@@ -211,7 +211,7 @@ final String _implCode = r'''
     final Map params = json['params'];
     if (method == 'streamNotify') {
       String streamId = params['streamId'];
-      _getEventController(streamId).add(createServiceObject(params['event']));
+      _getEventController(streamId).add(createServiceObject(params['event'], const ['Event']));
     } else {
       await _routeRequest(method, params);
     }
@@ -461,7 +461,7 @@ String decodeBase64(String str) => utf8.decode(base64.decode(str));
 bool _isNullInstance(Map json) => ((json['type'] == '@Instance') &&
                                   (json['kind'] == 'Null'));
 
-Object createServiceObject(dynamic json, [List<String> expectedTypes]) {
+Object createServiceObject(dynamic json, List<String> expectedTypes) {
   if (json == null) return null;
 
   if (json is List) {

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -31,6 +31,9 @@ String _coerceRefType(String typeName) {
   return typeName;
 }
 
+String _typeRefListToString(List<TypeRef> types) =>
+    '[' + types.map((e) => "'" + e.name + "'").join(',') + ']';
+
 final String _headerCode = r'''
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
@@ -178,7 +181,7 @@ final String _implCode = r'''
   void _processResponse(Map<String, dynamic> json) {
     Completer completer = _completers.remove(json['id']);
     String methodName = _methodCalls.remove(json['id']);
-    String returnType = _methodReturnTypes[methodName];
+    List<String> returnTypes = _methodReturnTypes[methodName];
     if (completer == null) {
       _log.severe('unmatched request response: ${jsonEncode(json)}');
     } else if (json['error'] != null) {
@@ -189,7 +192,7 @@ final String _implCode = r'''
       if (_typeFactories[type] == null) {
         completer.complete(Response.parse(result));
       } else {
-        completer.complete(createServiceObject(result, returnType));
+        completer.complete(createServiceObject(result, returnTypes));
       }
     }
   }
@@ -458,14 +461,14 @@ String decodeBase64(String str) => utf8.decode(base64.decode(str));
 bool _isNullInstance(Map json) => ((json['type'] == '@Instance') &&
                                   (json['kind'] == 'Null'));
 
-Object createServiceObject(dynamic json, [String expectedType]) {
+Object createServiceObject(dynamic json, [List<String> expectedTypes]) {
   if (json == null) return null;
 
   if (json is List) {
-    return json.map((e) => createServiceObject(e, expectedType)).toList();
+    return json.map((e) => createServiceObject(e, expectedTypes)).toList();
   } else if (json is Map) {
     String type = json['type'];
-    if (_isNullInstance(json) && (expectedType != type)) {
+    if (_isNullInstance(json) && (!expectedTypes.contains(type))) {
       return null;
     }
     if (_typeFactories[type] == null) {
@@ -513,9 +516,10 @@ typedef ServiceCallback = Future<Map<String, dynamic>> Function(
     gen.writeln('};');
     gen.writeln();
 
-    gen.writeln('Map<String, String> _methodReturnTypes = {');
+    gen.writeln('Map<String, List<String>> _methodReturnTypes = {');
     methods.forEach((Method method) {
-      gen.writeln("'${method.name}' : '${method.returnType.name}',");
+      String returnTypes = _typeRefListToString(method.returnType.types);
+      gen.writeln("'${method.name}' : $returnTypes,");
     });
     gen.writeln('};');
     gen.writeln();
@@ -1401,6 +1405,7 @@ class Type extends Member {
             "((dynamic list) => new List<int>.from(list)));");
       } else if (field.type.isArray) {
         TypeRef fieldType = field.type.types.first;
+        String typesList = _typeRefListToString(field.type.types);
         String ref = "json['${field.name}']";
         if (field.optional) {
           if (fieldType.isListTypeSimple) {
@@ -1408,7 +1413,7 @@ class Type extends Member {
                 "new List<${fieldType.listTypeArg}>.from($ref);");
           } else {
             gen.writeln("${field.generatableName} = $ref == null ? null : "
-                "new List<${fieldType.listTypeArg}>.from(createServiceObject($ref, '${fieldType.listTypeArg}'));");
+                "new List<${fieldType.listTypeArg}>.from(createServiceObject($ref, $typesList));");
           }
         } else {
           if (fieldType.isListTypeSimple) {
@@ -1426,16 +1431,17 @@ class Type extends Member {
             // field named 'samples' instead of 'instances'.
             if (name == 'InstanceSet') {
               gen.writeln("${field.generatableName} = "
-                  "new List<${fieldType.listTypeArg}>.from(createServiceObject($ref ?? json['samples'], '${fieldType.listTypeArg}'));");
+                  "new List<${fieldType.listTypeArg}>.from(createServiceObject($ref ?? json['samples'], $typesList));");
             } else {
               gen.writeln("${field.generatableName} = "
-                  "new List<${fieldType.listTypeArg}>.from(createServiceObject($ref, '${fieldType.listTypeArg}'));");
+                  "new List<${fieldType.listTypeArg}>.from(createServiceObject($ref, $typesList));");
             }
           }
         }
       } else {
+        String typesList = _typeRefListToString(field.type.types);
         gen.writeln("${field.generatableName} = "
-            "createServiceObject(json['${field.name}'], '${field.type.name}');");
+            "createServiceObject(json['${field.name}'], $typesList);");
       }
     });
     if (fields.isNotEmpty) {

--- a/dart/tool/dart/generate_dart.dart
+++ b/dart/tool/dart/generate_dart.dart
@@ -32,7 +32,7 @@ String _coerceRefType(String typeName) {
 }
 
 String _typeRefListToString(List<TypeRef> types) =>
-    '[' + types.map((e) => "'" + e.name + "'").join(',') + ']';
+    'const [' + types.map((e) => "'" + e.name + "'").join(',') + ']';
 
 final String _headerCode = r'''
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file

--- a/dart/tool/generate.dart
+++ b/dart/tool/generate.dart
@@ -24,7 +24,8 @@ main(List<String> args) async {
   var document = new Document();
   StringBuffer buf = new StringBuffer(file.readAsStringSync());
   buf.writeln();
-  buf.write(new File(join(appDirPath, 'service_undocumented.md')).readAsStringSync());
+  buf.write(
+      new File(join(appDirPath, 'service_undocumented.md')).readAsStringSync());
   var nodes = document.parseLines(buf.toString().split('\n'));
   print('Parsed ${file.path}.');
   print('Service protocol version ${ApiParseUtil.parseVersionString(nodes)}.');
@@ -115,7 +116,8 @@ void _stampPubspec(Version version) {
       Version v = new Version.parse(line.substring(pattern.length));
       String pre = v.preRelease.isEmpty ? null : v.preRelease.join('-');
       String build = v.build.isEmpty ? null : v.build.join('+');
-      v = new Version(version.major, version.minor, v.patch, pre: pre, build: build);
+      v = new Version(version.major, version.minor, v.patch,
+          pre: pre, build: build);
       return '${pattern}${v.toString()}';
     } else {
       return line;
@@ -133,6 +135,8 @@ void _checkUpdateChangelog(Version version) {
 
   File file = new File('CHANGELOG.md');
   String text = file.readAsStringSync();
-  bool containsReleaseNotes = text.split('\n').any((line) => line.startsWith(check));
-  if (!containsReleaseNotes) throw '`${check}` not found in the CHANGELOG.md file';
+  bool containsReleaseNotes =
+      text.split('\n').any((line) => line.startsWith(check));
+  if (!containsReleaseNotes)
+    throw '`${check}` not found in the CHANGELOG.md file';
 }

--- a/dart/tool/generate.dart
+++ b/dart/tool/generate.dart
@@ -137,6 +137,7 @@ void _checkUpdateChangelog(Version version) {
   String text = file.readAsStringSync();
   bool containsReleaseNotes =
       text.split('\n').any((line) => line.startsWith(check));
-  if (!containsReleaseNotes)
+  if (!containsReleaseNotes) {
     throw '`${check}` not found in the CHANGELOG.md file';
+  }
 }

--- a/dart/tool/java/generate_java.dart
+++ b/dart/tool/java/generate_java.dart
@@ -1218,12 +1218,16 @@ class TypeRef {
           writer.addLine('return new $name(child);');
         } else {
           if (optional) {
-            writer.addLine('JsonObject obj = (JsonObject) json.get("$propertyName");');
+            writer.addLine(
+                'JsonObject obj = (JsonObject) json.get("$propertyName");');
             writer.addLine('if (obj == null) return null;');
             if ((name != 'InstanceRef') && (name != 'Instance')) {
-              writer.addLine('final String type = json.get("type").getAsString();');
-              writer.addLine('if ("Instance".equals(type) || "@Instance".equals(type)) {');
-              writer.addLine('  final String kind = json.get("kind").getAsString();');
+              writer.addLine(
+                  'final String type = json.get("type").getAsString();');
+              writer.addLine(
+                  'if ("Instance".equals(type) || "@Instance".equals(type)) {');
+              writer.addLine(
+                  '  final String kind = json.get("kind").getAsString();');
               writer.addLine('  if ("Null".equals(kind)) return null;');
               writer.addLine('}');
             }

--- a/dart/tool/java/generate_java.dart
+++ b/dart/tool/java/generate_java.dart
@@ -1218,8 +1218,16 @@ class TypeRef {
           writer.addLine('return new $name(child);');
         } else {
           if (optional) {
-            writer.addLine('return json.get("$propertyName") == null ? '
-                'null : new $name((JsonObject) json.get("$propertyName"));');
+            writer.addLine('JsonObject obj = (JsonObject) json.get("$propertyName");');
+            writer.addLine('if (obj == null) return null;');
+            if ((name != 'InstanceRef') && (name != 'Instance')) {
+              writer.addLine('final String type = json.get("type").getAsString();');
+              writer.addLine('if ("Instance".equals(type) || "@Instance".equals(type)) {');
+              writer.addLine('  final String kind = json.get("kind").getAsString();');
+              writer.addLine('  if ("Null".equals(kind)) return null;');
+              writer.addLine('}');
+            }
+            writer.addLine('return new $name(obj);');
           } else {
             writer.addLine(
                 'return new $name((JsonObject) json.get("$propertyName"));');

--- a/dart/tool/service.md
+++ b/dart/tool/service.md
@@ -2086,13 +2086,11 @@ class Instance extends Object {
   //   Closure
   @Function closureFunction [optional];
 
-  // TODO(devoncarew): this can return an InstanceRef
-  //
   // The context associated with a Closure instance.
   //
   // Provided for instance kinds:
   //   Closure
-  //@Context closureContext [optional];
+  @Context closureContext [optional];
 
   // The referent of a MirrorReference instance.
   //

--- a/java/src/org/dartlang/vm/service/element/ClassObj.java
+++ b/java/src/org/dartlang/vm/service/element/ClassObj.java
@@ -34,7 +34,14 @@ public class ClassObj extends Obj {
    * Can return <code>null</code>.
    */
   public ErrorRef getError() {
-    return json.get("error") == null ? null : new ErrorRef((JsonObject) json.get("error"));
+    JsonObject obj = (JsonObject) json.get("error");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ErrorRef(obj);
   }
 
   /**
@@ -89,7 +96,14 @@ public class ClassObj extends Obj {
    * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
-    return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
+    JsonObject obj = (JsonObject) json.get("location");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new SourceLocation(obj);
   }
 
   /**
@@ -100,7 +114,9 @@ public class ClassObj extends Obj {
    * Can return <code>null</code>.
    */
   public InstanceRef getMixin() {
-    return json.get("mixin") == null ? null : new InstanceRef((JsonObject) json.get("mixin"));
+    JsonObject obj = (JsonObject) json.get("mixin");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**
@@ -128,7 +144,14 @@ public class ClassObj extends Obj {
    * Can return <code>null</code>.
    */
   public ClassRef getSuperClass() {
-    return json.get("super") == null ? null : new ClassRef((JsonObject) json.get("super"));
+    JsonObject obj = (JsonObject) json.get("super");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ClassRef(obj);
   }
 
   /**
@@ -139,7 +162,9 @@ public class ClassObj extends Obj {
    * Can return <code>null</code>.
    */
   public InstanceRef getSuperType() {
-    return json.get("superType") == null ? null : new InstanceRef((JsonObject) json.get("superType"));
+    JsonObject obj = (JsonObject) json.get("superType");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/Context.java
+++ b/java/src/org/dartlang/vm/service/element/Context.java
@@ -41,7 +41,14 @@ public class Context extends Obj {
    * Can return <code>null</code>.
    */
   public Context getParent() {
-    return json.get("parent") == null ? null : new Context((JsonObject) json.get("parent"));
+    JsonObject obj = (JsonObject) json.get("parent");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new Context(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/ErrorObj.java
+++ b/java/src/org/dartlang/vm/service/element/ErrorObj.java
@@ -34,7 +34,9 @@ public class ErrorObj extends Obj {
    * Can return <code>null</code>.
    */
   public InstanceRef getException() {
-    return json.get("exception") == null ? null : new InstanceRef((JsonObject) json.get("exception"));
+    JsonObject obj = (JsonObject) json.get("exception");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**
@@ -62,6 +64,8 @@ public class ErrorObj extends Obj {
    * Can return <code>null</code>.
    */
   public InstanceRef getStacktrace() {
-    return json.get("stacktrace") == null ? null : new InstanceRef((JsonObject) json.get("stacktrace"));
+    JsonObject obj = (JsonObject) json.get("stacktrace");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 }

--- a/java/src/org/dartlang/vm/service/element/Event.java
+++ b/java/src/org/dartlang/vm/service/element/Event.java
@@ -67,7 +67,14 @@ public class Event extends Response {
    * Can return <code>null</code>.
    */
   public Breakpoint getBreakpoint() {
-    return json.get("breakpoint") == null ? null : new Breakpoint((JsonObject) json.get("breakpoint"));
+    JsonObject obj = (JsonObject) json.get("breakpoint");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new Breakpoint(obj);
   }
 
   /**
@@ -87,7 +94,9 @@ public class Event extends Response {
    * Can return <code>null</code>.
    */
   public InstanceRef getException() {
-    return json.get("exception") == null ? null : new InstanceRef((JsonObject) json.get("exception"));
+    JsonObject obj = (JsonObject) json.get("exception");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**
@@ -98,7 +107,14 @@ public class Event extends Response {
    * Can return <code>null</code>.
    */
   public ExtensionData getExtensionData() {
-    return json.get("extensionData") == null ? null : new ExtensionData((JsonObject) json.get("extensionData"));
+    JsonObject obj = (JsonObject) json.get("extensionData");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ExtensionData(obj);
   }
 
   /**
@@ -131,7 +147,9 @@ public class Event extends Response {
    * Can return <code>null</code>.
    */
   public InstanceRef getInspectee() {
-    return json.get("inspectee") == null ? null : new InstanceRef((JsonObject) json.get("inspectee"));
+    JsonObject obj = (JsonObject) json.get("inspectee");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**
@@ -143,7 +161,14 @@ public class Event extends Response {
    * Can return <code>null</code>.
    */
   public IsolateRef getIsolate() {
-    return json.get("isolate") == null ? null : new IsolateRef((JsonObject) json.get("isolate"));
+    JsonObject obj = (JsonObject) json.get("isolate");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new IsolateRef(obj);
   }
 
   /**
@@ -166,7 +191,14 @@ public class Event extends Response {
    * Can return <code>null</code>.
    */
   public LogRecord getLogRecord() {
-    return json.get("logRecord") == null ? null : new LogRecord((JsonObject) json.get("logRecord"));
+    JsonObject obj = (JsonObject) json.get("logRecord");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new LogRecord(obj);
   }
 
   /**
@@ -275,7 +307,14 @@ public class Event extends Response {
    * Can return <code>null</code>.
    */
   public Frame getTopFrame() {
-    return json.get("topFrame") == null ? null : new Frame((JsonObject) json.get("topFrame"));
+    JsonObject obj = (JsonObject) json.get("topFrame");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new Frame(obj);
   }
 
   /**
@@ -287,6 +326,13 @@ public class Event extends Response {
    * Can return <code>null</code>.
    */
   public VMRef getVm() {
-    return json.get("vm") == null ? null : new VMRef((JsonObject) json.get("vm"));
+    JsonObject obj = (JsonObject) json.get("vm");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new VMRef(obj);
   }
 }

--- a/java/src/org/dartlang/vm/service/element/Field.java
+++ b/java/src/org/dartlang/vm/service/element/Field.java
@@ -42,7 +42,14 @@ public class Field extends Obj {
    * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
-    return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
+    JsonObject obj = (JsonObject) json.get("location");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new SourceLocation(obj);
   }
 
   /**
@@ -65,7 +72,9 @@ public class Field extends Obj {
    * Can return <code>null</code>.
    */
   public InstanceRef getStaticValue() {
-    return json.get("staticValue") == null ? null : new InstanceRef((JsonObject) json.get("staticValue"));
+    JsonObject obj = (JsonObject) json.get("staticValue");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/Frame.java
+++ b/java/src/org/dartlang/vm/service/element/Frame.java
@@ -30,14 +30,28 @@ public class Frame extends Response {
    * Can return <code>null</code>.
    */
   public CodeRef getCode() {
-    return json.get("code") == null ? null : new CodeRef((JsonObject) json.get("code"));
+    JsonObject obj = (JsonObject) json.get("code");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new CodeRef(obj);
   }
 
   /**
    * Can return <code>null</code>.
    */
   public FuncRef getFunction() {
-    return json.get("function") == null ? null : new FuncRef((JsonObject) json.get("function"));
+    JsonObject obj = (JsonObject) json.get("function");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new FuncRef(obj);
   }
 
   public int getIndex() {
@@ -62,7 +76,14 @@ public class Frame extends Response {
    * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
-    return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
+    JsonObject obj = (JsonObject) json.get("location");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new SourceLocation(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/Func.java
+++ b/java/src/org/dartlang/vm/service/element/Func.java
@@ -33,7 +33,14 @@ public class Func extends Obj {
    * Can return <code>null</code>.
    */
   public CodeRef getCode() {
-    return json.get("code") == null ? null : new CodeRef((JsonObject) json.get("code"));
+    JsonObject obj = (JsonObject) json.get("code");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new CodeRef(obj);
   }
 
   /**
@@ -42,7 +49,14 @@ public class Func extends Obj {
    * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
-    return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
+    JsonObject obj = (JsonObject) json.get("location");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new SourceLocation(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/Instance.java
+++ b/java/src/org/dartlang/vm/service/element/Instance.java
@@ -60,7 +60,9 @@ public class Instance extends Obj {
    * Can return <code>null</code>.
    */
   public InstanceRef getBound() {
-    return json.get("bound") == null ? null : new InstanceRef((JsonObject) json.get("bound"));
+    JsonObject obj = (JsonObject) json.get("bound");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**
@@ -99,6 +101,25 @@ public class Instance extends Obj {
   }
 
   /**
+   * The context associated with a Closure instance.
+   *
+   * Provided for instance kinds:
+   *  - Closure
+   *
+   * Can return <code>null</code>.
+   */
+  public ContextRef getClosureContext() {
+    JsonObject obj = (JsonObject) json.get("closureContext");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ContextRef(obj);
+  }
+
+  /**
    * The function associated with a Closure instance.
    *
    * Provided for instance kinds:
@@ -107,7 +128,14 @@ public class Instance extends Obj {
    * Can return <code>null</code>.
    */
   public FuncRef getClosureFunction() {
-    return json.get("closureFunction") == null ? null : new FuncRef((JsonObject) json.get("closureFunction"));
+    JsonObject obj = (JsonObject) json.get("closureFunction");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new FuncRef(obj);
   }
 
   /**
@@ -242,12 +270,7 @@ public class Instance extends Obj {
   }
 
   /**
-   * TODO(devoncarew): this can return an InstanceRef
-   *
-   * The context associated with a Closure instance.
-   *
-   * Provided for instance kinds:
-   *  - Closure@Context closureContext [optional]; The referent of a MirrorReference instance.
+   * The referent of a MirrorReference instance.
    *
    * Provided for instance kinds:
    *  - MirrorReference
@@ -255,7 +278,9 @@ public class Instance extends Obj {
    * Can return <code>null</code>.
    */
   public InstanceRef getMirrorReferent() {
-    return json.get("mirrorReferent") == null ? null : new InstanceRef((JsonObject) json.get("mirrorReferent"));
+    JsonObject obj = (JsonObject) json.get("mirrorReferent");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**
@@ -320,7 +345,14 @@ public class Instance extends Obj {
    * Can return <code>null</code>.
    */
   public ClassRef getParameterizedClass() {
-    return json.get("parameterizedClass") == null ? null : new ClassRef((JsonObject) json.get("parameterizedClass"));
+    JsonObject obj = (JsonObject) json.get("parameterizedClass");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ClassRef(obj);
   }
 
   /**
@@ -344,7 +376,9 @@ public class Instance extends Obj {
    * Can return <code>null</code>.
    */
   public InstanceRef getPropertyKey() {
-    return json.get("propertyKey") == null ? null : new InstanceRef((JsonObject) json.get("propertyKey"));
+    JsonObject obj = (JsonObject) json.get("propertyKey");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**
@@ -356,7 +390,9 @@ public class Instance extends Obj {
    * Can return <code>null</code>.
    */
   public InstanceRef getPropertyValue() {
-    return json.get("propertyValue") == null ? null : new InstanceRef((JsonObject) json.get("propertyValue"));
+    JsonObject obj = (JsonObject) json.get("propertyValue");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**
@@ -371,7 +407,9 @@ public class Instance extends Obj {
    * Can return <code>null</code>.
    */
   public InstanceRef getTargetType() {
-    return json.get("targetType") == null ? null : new InstanceRef((JsonObject) json.get("targetType"));
+    JsonObject obj = (JsonObject) json.get("targetType");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**
@@ -383,7 +421,14 @@ public class Instance extends Obj {
    * Can return <code>null</code>.
    */
   public TypeArgumentsRef getTypeArguments() {
-    return json.get("typeArguments") == null ? null : new TypeArgumentsRef((JsonObject) json.get("typeArguments"));
+    JsonObject obj = (JsonObject) json.get("typeArguments");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new TypeArgumentsRef(obj);
   }
 
   /**
@@ -395,7 +440,14 @@ public class Instance extends Obj {
    * Can return <code>null</code>.
    */
   public ClassRef getTypeClass() {
-    return json.get("typeClass") == null ? null : new ClassRef((JsonObject) json.get("typeClass"));
+    JsonObject obj = (JsonObject) json.get("typeClass");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ClassRef(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/InstanceRef.java
+++ b/java/src/org/dartlang/vm/service/element/InstanceRef.java
@@ -97,7 +97,14 @@ public class InstanceRef extends ObjRef {
    * Can return <code>null</code>.
    */
   public ClassRef getParameterizedClass() {
-    return json.get("parameterizedClass") == null ? null : new ClassRef((JsonObject) json.get("parameterizedClass"));
+    JsonObject obj = (JsonObject) json.get("parameterizedClass");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ClassRef(obj);
   }
 
   /**
@@ -111,7 +118,9 @@ public class InstanceRef extends ObjRef {
    * Can return <code>null</code>.
    */
   public InstanceRef getPattern() {
-    return json.get("pattern") == null ? null : new InstanceRef((JsonObject) json.get("pattern"));
+    JsonObject obj = (JsonObject) json.get("pattern");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
   }
 
   /**
@@ -123,7 +132,14 @@ public class InstanceRef extends ObjRef {
    * Can return <code>null</code>.
    */
   public ClassRef getTypeClass() {
-    return json.get("typeClass") == null ? null : new ClassRef((JsonObject) json.get("typeClass"));
+    JsonObject obj = (JsonObject) json.get("typeClass");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ClassRef(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/Isolate.java
+++ b/java/src/org/dartlang/vm/service/element/Isolate.java
@@ -48,7 +48,14 @@ public class Isolate extends Response {
    * Can return <code>null</code>.
    */
   public ErrorObj getError() {
-    return json.get("error") == null ? null : new ErrorObj((JsonObject) json.get("error"));
+    JsonObject obj = (JsonObject) json.get("error");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ErrorObj(obj);
   }
 
   /**
@@ -137,7 +144,14 @@ public class Isolate extends Response {
    * Can return <code>null</code>.
    */
   public LibraryRef getRootLib() {
-    return json.get("rootLib") == null ? null : new LibraryRef((JsonObject) json.get("rootLib"));
+    JsonObject obj = (JsonObject) json.get("rootLib");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new LibraryRef(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/Message.java
+++ b/java/src/org/dartlang/vm/service/element/Message.java
@@ -34,7 +34,14 @@ public class Message extends Response {
    * Can return <code>null</code>.
    */
   public FuncRef getHandler() {
-    return json.get("handler") == null ? null : new FuncRef((JsonObject) json.get("handler"));
+    JsonObject obj = (JsonObject) json.get("handler");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new FuncRef(obj);
   }
 
   /**
@@ -51,7 +58,14 @@ public class Message extends Response {
    * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
-    return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
+    JsonObject obj = (JsonObject) json.get("location");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new SourceLocation(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/Obj.java
+++ b/java/src/org/dartlang/vm/service/element/Obj.java
@@ -38,7 +38,14 @@ public class Obj extends Response {
    * Can return <code>null</code>.
    */
   public ClassRef getClassRef() {
-    return json.get("class") == null ? null : new ClassRef((JsonObject) json.get("class"));
+    JsonObject obj = (JsonObject) json.get("class");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ClassRef(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/SourceReportRange.java
+++ b/java/src/org/dartlang/vm/service/element/SourceReportRange.java
@@ -43,7 +43,14 @@ public class SourceReportRange extends Element {
    * Can return <code>null</code>.
    */
   public SourceReportCoverage getCoverage() {
-    return json.get("coverage") == null ? null : new SourceReportCoverage((JsonObject) json.get("coverage"));
+    JsonObject obj = (JsonObject) json.get("coverage");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new SourceReportCoverage(obj);
   }
 
   /**
@@ -60,7 +67,14 @@ public class SourceReportRange extends Element {
    * Can return <code>null</code>.
    */
   public ErrorRef getError() {
-    return json.get("error") == null ? null : new ErrorRef((JsonObject) json.get("error"));
+    JsonObject obj = (JsonObject) json.get("error");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ErrorRef(obj);
   }
 
   /**

--- a/java/src/org/dartlang/vm/service/element/UnresolvedSourceLocation.java
+++ b/java/src/org/dartlang/vm/service/element/UnresolvedSourceLocation.java
@@ -55,7 +55,14 @@ public class UnresolvedSourceLocation extends Response {
    * Can return <code>null</code>.
    */
   public ScriptRef getScript() {
-    return json.get("script") == null ? null : new ScriptRef((JsonObject) json.get("script"));
+    JsonObject obj = (JsonObject) json.get("script");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new ScriptRef(obj);
   }
 
   /**


### PR DESCRIPTION
When creating a service object, we check to see if Instance::null was
returned and compare the actual type against the expected type of the
object. If there's an Instance::null response and the object isn't
expected to be of type Instance, null is returned.