### PR TITLE
Changed type of property library in Class from ObjectRef to LibraryRef.

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.22.1
+- **breaking**: Changed type of `library` property in `Class` objects from
+  `ObjectRef` to `LibraryRef`.
+
 ## 3.22.0
 - The `registerService` RPC and `Service` stream are now public.
 - `Event` has been updated to include the optional `service`, `method`, and

--- a/dart/example/vm_service_assert.dart
+++ b/dart/example/vm_service_assert.dart
@@ -324,7 +324,7 @@ vms.Class assertClass(vms.Class obj) {
   assertString(obj.name);
   assertBool(obj.isAbstract);
   assertBool(obj.isConst);
-  assertObjRef(obj.library);
+  assertLibraryRef(obj.library);
   assertInstanceRefs(obj.interfaces);
   assertFieldRefs(obj.fields);
   assertFuncRefs(obj.functions);

--- a/dart/lib/vm_service_lib.dart
+++ b/dart/lib/vm_service_lib.dart
@@ -173,6 +173,7 @@ Map<String, List<String>> _methodReturnTypes = {
   'getVMTimelineMicros': const ['Timestamp'],
   'pause': const ['Success'],
   'kill': const ['Success'],
+  'registerService': const ['Success'],
   'reloadSources': const ['ReloadReport'],
   'removeBreakpoint': const ['Success'],
   'resume': const ['Success'],
@@ -188,7 +189,6 @@ Map<String, List<String>> _methodReturnTypes = {
   '_requestHeapSnapshot': const ['Success'],
   '_clearCpuProfile': const ['Success'],
   '_getCpuProfile': const ['_CpuProfile'],
-  '_registerService': const ['Success'],
 };
 
 /// A class representation of the Dart VM Service Protocol.
@@ -2306,9 +2306,8 @@ class Class extends Obj {
   /// Is this a const class?
   bool isConst;
 
-  /// The library which contains this class. TODO: This should be @Library, but
-  /// the VM can return @Instance objects here.
-  ObjRef library;
+  /// The library which contains this class.
+  LibraryRef library;
 
   /// The location of this class in the source code.
   @optional
@@ -2352,7 +2351,7 @@ class Class extends Obj {
     error = createServiceObject(json['error'], const ['ErrorRef']);
     isAbstract = json['abstract'];
     isConst = json['const'];
-    library = createServiceObject(json['library'], const ['ObjRef']);
+    library = createServiceObject(json['library'], const ['LibraryRef']);
     location = createServiceObject(json['location'], const ['SourceLocation']);
     superClass = createServiceObject(json['super'], const ['ClassRef']);
     superType = createServiceObject(json['superType'], const ['InstanceRef']);

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vm_service_lib
 description: A library to access the VM Service API.
-version: 3.22.0
+version: 3.22.1
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_drivers

--- a/dart/tool/service.md
+++ b/dart/tool/service.md
@@ -1309,8 +1309,7 @@ class Class extends Object {
   bool const;
 
   // The library which contains this class.
-  // TODO: This should be @Library, but the VM can return @Instance objects here.
-  @Object library;
+  @Library library;
 
   // The location of this class in the source code.
   SourceLocation location [optional];

--- a/java/src/org/dartlang/vm/service/element/ClassObj.java
+++ b/java/src/org/dartlang/vm/service/element/ClassObj.java
@@ -83,11 +83,10 @@ public class ClassObj extends Obj {
   }
 
   /**
-   * The library which contains this class. TODO: This should be @Library, but the VM can return
-   * @Instance objects here.
+   * The library which contains this class.
    */
-  public ObjRef getLibrary() {
-    return new ObjRef((JsonObject) json.get("library"));
+  public LibraryRef getLibrary() {
+    return new LibraryRef((JsonObject) json.get("library"));
   }
 
   /**


### PR DESCRIPTION
This property should never be an Instance and should probably never be null. If that's the case we'll need a proper fix, but we'll need more information to determine what's happening. If library is null, it should now be handled and converted to null instead of Instance::null, although this should never be the case and is likely a bug.

This is the last change needed before this package can start being pulled into the SDK.